### PR TITLE
add a skipnodes option to speed up sitesync

### DIFF
--- a/plsync/planetlab/types.py
+++ b/plsync/planetlab/types.py
@@ -260,10 +260,16 @@ class Site(dict):
 
         super(Site, self).__init__(**kwargs)
 
-    def sync(self, onhost=None, skipinterfaces=False, getbootimages=False):
+    def sync(self, onhost=None, skipnodes=False, skipinterfaces=False,
+             getbootimages=False):
         """ Do whatever is necessary to validate this site in the myplc DB.
             Actions may include creating a new Site() entry in myPLC DB, 
             creating people listed as PIs, creating nodes and PCUs.  
+
+            onhost - string, limit actions on site to a single host
+            skipnodes - if True, skipnodes entirely
+            skipinterfaces - if True, skip configuration of interfaces
+            getbootimages - if True, also download node bootimages to .iso
         """
         MakeSite(self['login_base'], self['sitename'], self['sitename'])
         SyncLocation(self['login_base'], self['location'])
@@ -272,9 +278,10 @@ class Site(dict):
             email = person[2]
             AddPersonToSite(email,p_id,"tech",self['login_base'])
             AddPersonToSite(email,p_id,"pi",self['login_base'])
-        for hostname,node in self['nodes'].iteritems():
-            if onhost is None or hostname == onhost:
-                node.sync(skipinterfaces, getbootimages)
+        if not skipnodes:
+            for hostname,node in self['nodes'].iteritems():
+                if onhost is None or hostname == onhost:
+                    node.sync(skipinterfaces, getbootimages)
 
 def makesite(name, v4prefix, v6prefix, city, country, 
              latitude, longitude, pi_list, **kwargs):

--- a/plsync/plsync.py
+++ b/plsync/plsync.py
@@ -85,6 +85,7 @@ def main():
                         slicelist="slice_list",
                         skipsliceips=False, 
                         skipinterfaces=False,
+                        skipnodes=False,
                         createslice=False,
                         getbootimages=False,
                         url=session.API_URL, debug=False, verbose=False, )
@@ -116,7 +117,11 @@ def main():
                 help=("dont try to create new Interfaces or update existing "+
                       "Interfaces. This permits IPv6 maniuplation without "+
                       "changing legacy IPv4 configuration in DB.") )
-    parser.add_option("", "--createslice", action="store_true", dest="createslice", 
+    parser.add_option("", "--skipnodes", dest="skipnodes",
+                action="store_true",
+                help=("dont create nodes during site sync (saves time)"))
+    parser.add_option("", "--createslice", action="store_true",
+                dest="createslice",
                 help=("Normally, slices are assumed to exist. This option "+
                       "creates them first. Useful for testing."))
     parser.add_option("", "--getbootimages", dest="getbootimages", 
@@ -163,8 +168,8 @@ def main():
             if (options.syncsite == "all" or 
                 options.syncsite == site['name']):
                 print "Syncing: site", site['name']
-                site.sync(options.ondest, options.skipinterfaces, 
-                          options.getbootimages)
+                site.sync(options.ondest, options.skipnodes,
+                          options.skipinterfaces, options.getbootimages)
 
     elif options.syncslice is not None and options.syncsite is None:
         print options.syncslice


### PR DESCRIPTION
This is helpful when adding a new user as a PI/tech for all M-Lab sites:

```
./plsync.py --syncsite all --skipnodes
```
