### PR TITLE
Programatically identify PREFIX directory of drac.py

### DIFF
--- a/tools/drac.py
+++ b/tools/drac.py
@@ -372,9 +372,9 @@ def main():
             sys.exit(1)
 
         for hostname,user,passwd,model in pcu_fields:
-            #if model != "DRAC":
-            #    print "%s is an unsupported PCU model" % model
-            #    continue
+            if model != "DRAC":
+                print "%s is an unsupported PCU model" % model
+                continue
 
             system("expect %s/exp/GETSYSINFO.exp %s %s '%s'" %
                    (PREFIX, hostname, user, passwd))


### PR DESCRIPTION
Programatically identify full path to tools/drac.py directory.  

This patch identifies the installation directory of the drac.py script, and prepends this prefix to every call of the plcquery.py script and to expect scripts. 

Previously the path was assumed to be PWD.
