### PR TITLE
gdict format fix

### DIFF
--- a/tools/gdict.py
+++ b/tools/gdict.py
@@ -58,8 +58,10 @@ def usage():
         --results "command {c1}"
 
     The following characters are reserved: '_', '{', '}'
-       '_' Interpreted by gdata, column names should not use this character.
-       '{' or '}' Used in string formatting, there are no literal braces.
+       '_' is interpreted by the gdata module when used in column names.
+           However, underscore can be anywhere else.
+       '{' and '}' are used in string formatting. They are replaced and the
+           --result "command format" should not include extra braces.
 
     To indicate success, the script should have an exit value of zero. To have
     new values added to the current key, the script should print column,value


### PR DESCRIPTION
Python supports two types of string formatting conventions for dict's:
- old style using: `"%(keyname)s" % dict`
- new style using: `"{keyname}".format(keyname=value)`

The original version of gdict.py used the new-style, because it is supported natively by the string.format() method, and the `{}` syntax is easier to read.

The column names provided to gdict are user-provided.  And, the keyname=value arguments to format() were provided by `.format(**args)`.  This limits keynames to valid python identifiers only.  This excludes column names like "site.host" or "foo-bar".

To support these and keep the new-style syntax, this patch replaces `{}` using string substitution with the old-style syntax `%()s`.  The usage() string also includes a note on reserved characters now.
