### PR TITLE
check that given user_list is a list

### DIFF
--- a/plsync/planetlab/sync.py
+++ b/plsync/planetlab/sync.py
@@ -575,6 +575,10 @@ def SyncPersonsOnSlice(slicename, user_list):
     Returns:
         None
     """
+    if type(user_list) is not list:
+        print "No user_list provided for adding to %s" % slicename
+        return
+
     members_of_slice = GetPersonsOnSlice(slicename)
     member_emails = [ p['email'] for p in members_of_slice ]
     delcared_emails = [ email for fn,ln,email in user_list ]


### PR DESCRIPTION
the 'users' option to Slice() objects is optional, so we need to confirm that only valid user_lists are used.
