### PR TITLE
Remove extra & conflicting slice tag from gt_bismark

### DIFF
--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -120,7 +120,7 @@ slice_list = [
     Slice(name="samknows_ispmon", index=7, attrs=centos_slice_attrs+web100_enable_attr,
                                            users=user_list,
                                            ipv6="all"),
-    Slice(name="gt_bismark",      index=8, attrs=centos_slice_attrs+web100_enable_attr+[
+    Slice(name="gt_bismark",      index=8, attrs=centos_slice_attrs+[
                                                 Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ], 
                                            users=user_list,
                                            ipv6=mlab4s_only),


### PR DESCRIPTION
This is undocumented behavior. Unfortunately not all slice tags behave the same way.

For the 'capabilities' slice tag, a slice only gets one per node. By having:

    web100_enable_attr + [Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ]

There are two, and when running plsync multiple times, these values may reset the tag unpredictably. For example:

    UPDATING : gt_bismark -> (capabilities,None,MeasurementLabCentos)
             : from 'CAP_NET_BIND_SERVICE,vxc_^28' to 'vxc_^28'
    UPDATING : gt_bismark -> (capabilities,None,MeasurementLabCentos)
             : from 'vxc_^28' to 'CAP_NET_BIND_SERVICE,vxc_^28'

This change eliminates the ambiguity.