### PR TITLE
Change ipv6 config setting for NDT slice

### DIFF
--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -90,7 +90,9 @@ slice_list = [
                                                 Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ], 
                                            users=user_list,
                                            use_initscript=True,
-                                           ipv6="nuq1t nuq02 lga06" ),
+                                           ipv6=['mlab1.nuq1t', 'mlab2.nuq1t', 'mlab3.nuq1t', 'mlab4.nuq1t',
+                                                 'mlab1.nuq02', 'mlab2.nuq02', 'mlab3.nuq02', 'mlab4.nuq02',
+                                                 'mlab1.lga06', 'mlab2.lga06', 'mlab3.lga06', 'mlab4.lga06']),
     Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+web100_enable_attr+[
                                                 Attr('MeasurementLabCentos',    disk_max='10000000'),
                                                 Attr(None,    vsys='web100_proc_write'), ],

--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -91,7 +91,7 @@ slice_list = [
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6=['mlab1.nuq1t', 'mlab2.nuq1t', 'mlab3.nuq1t', 'mlab4.nuq1t',
-                                                 'mlab1.nuq02', 'mlab2.nuq02', 'mlab3.nuq02', 'mlab4.nuq02',
+                                                 'mlab1.nuq02', 'mlab2.nuq02', 'mlab3.nuq02',
                                                  'mlab1.lga06', 'mlab2.lga06', 'mlab3.lga06', 'mlab4.lga06']),
     Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+web100_enable_attr+[
                                                 Attr('MeasurementLabCentos',    disk_max='10000000'),


### PR DESCRIPTION
The ipv6 setting expects a list of explicit host names. It treats any string value as "all".

The previous value was providing ipv6 to all slices. This change limits ipv6 to the machines at the sites listed previously.