### PR TITLE
Add accessor methods for zone generation.

### DIFF
--- a/plsync/planetlab/model_test.py
+++ b/plsync/planetlab/model_test.py
@@ -4,7 +4,7 @@ import model
 import unittest
 
 
-class TypesTest(unittest.TestCase):
+class ModelTest(unittest.TestCase):
 
     def setUp(self):
         self.users = [('User', 'Name', 'username@gmail.com')]
@@ -19,6 +19,53 @@ class TypesTest(unittest.TestCase):
         # Assign experiments to nodes.
         for hostname, node in self.sites[0]['nodes'].iteritems():
             self.experiments[0].add_node_address(node)
+
+    def test_site_ipv4(self):
+        expected_ip = '192.168.1.2'
+        site = self.sites[0]
+
+        ip = site.ipv4(index=2)
+
+        self.assertEqual(expected_ip, ip)
+
+    def test_pcu_hostname(self):
+        expcted_hostnames = [
+            'mlab1d.abc01.measurement-lab.org',
+            'mlab2d.abc01.measurement-lab.org',
+            'mlab3d.abc01.measurement-lab.org'
+        ]
+        hostnames = []
+
+        for node in self.sites[0]['nodes'].values():
+            hostnames.append(node['pcu'].hostname())
+
+        self.assertItemsEqual(expcted_hostnames, hostnames)
+
+    def test_pcu_recordname(self):
+        expected_names = [
+            'mlab1d.abc01',
+            'mlab2d.abc01',
+            'mlab3d.abc01'
+        ]
+        names = []
+
+        for node in self.sites[0]['nodes'].values():
+            names.append(node['pcu'].recordname())
+
+        self.assertItemsEqual(expected_names, names)
+
+    def test_pcu_ipv4(self):
+        expected_ips = [
+            '192.168.1.4',
+            '192.168.1.5',
+            '192.168.1.6'
+        ]
+        ips = []
+
+        for node in self.sites[0]['nodes'].values():
+            ips.append(node['pcu'].ipv4())
+
+        self.assertItemsEqual(expected_ips, ips)
 
     def test_node_ipv4_and_ipv6(self):
         ipv4s = []
@@ -94,6 +141,31 @@ class TypesTest(unittest.TestCase):
         self.assertEqual('abcdef', onename)
         self.assertEqual('def.abc', twoname)
         self.assertEqual('def.ghi.abc', multiname)
+
+    def test_slice_sitename(self):
+        names = []
+        expected_name = 'bar.abc.abc01'
+
+        for experiment in self.experiments:
+            for _, node in experiment['network_list']:
+                names.append(experiment.sitename(node))
+
+        self.assertEqual(1, len(set(names)))
+        self.assertEqual(expected_name, names[0])
+
+    def test_slice_recordname(self):
+        names = []
+        expected_names = [
+           'bar.abc.mlab1.abc01',
+           'bar.abc.mlab2.abc01',
+           'bar.abc.mlab3.abc01'
+        ]
+
+        for experiment in self.experiments:
+            for _, node in experiment['network_list']:
+                names.append(experiment.recordname(node))
+
+        self.assertItemsEqual(expected_names, names)
 
 
 if __name__ == '__main__':

--- a/plsync/planetlab/model_test.py
+++ b/plsync/planetlab/model_test.py
@@ -29,7 +29,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(expected_ip, ip)
 
     def test_pcu_hostname(self):
-        expcted_hostnames = [
+        expected_hostnames = [
             'mlab1d.abc01.measurement-lab.org',
             'mlab2d.abc01.measurement-lab.org',
             'mlab3d.abc01.measurement-lab.org'
@@ -39,7 +39,7 @@ class ModelTest(unittest.TestCase):
         for node in self.sites[0]['nodes'].values():
             hostnames.append(node['pcu'].hostname())
 
-        self.assertItemsEqual(expcted_hostnames, hostnames)
+        self.assertItemsEqual(expected_hostnames, hostnames)
 
     def test_pcu_recordname(self):
         expected_names = [

--- a/plsync/planetlab/model_test.py
+++ b/plsync/planetlab/model_test.py
@@ -150,6 +150,7 @@ class ModelTest(unittest.TestCase):
             for _, node in experiment['network_list']:
                 names.append(experiment.sitename(node))
 
+        # Guarantee that there is only one unique experiment site name.
         self.assertEqual(1, len(set(names)))
         self.assertEqual(expected_name, names[0])
 


### PR DESCRIPTION
This change adds new accessor methods on Site, PCU, and Slice classes to assist with DNS zone generation.