### PR TITLE
Add zone generation support to mlabconfig.py

### DIFF
--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -37,11 +37,11 @@ EXAMPLES:
 def parse_flags():
     parser = optparse.OptionParser(usage=usage())
     parser.set_defaults(force=False,
-                        support_email="support.measurementlab.net",
-                        primary_nameserver="ns.chambana.net",
-                        secondary_nameserver="sns-pb.isc.org",
-                        domain="measurement-lab.org",
-                        serial="auto",
+                        support_email='support.measurementlab.net',
+                        primary_nameserver='ns.chambana.net',
+                        secondary_nameserver='sns-pb.isc.org',
+                        domain='measurement-lab.org',
+                        serial='auto',
                         zonefile=None,
                         ttl=ZONE_TTL,
                         minttl=ZONE_MIN_TTL,

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -107,82 +107,82 @@ def format_aaaa_record(hostname, ipv6):
 
 
 def export_router_and_switch_records(output, sites):
-  comment(output, 'router and switch v4 records.')
-  for i, site in enumerate(sites):
-      write_a_record(output, 'r1.' + site['name'], site.ipv4(index=1))
-      write_a_record(output, 's1.' + site['name'], site.ipv4(index=2))
+    comment(output, 'router and switch v4 records.')
+    for i, site in enumerate(sites):
+        write_a_record(output, 'r1.' + site['name'], site.ipv4(index=1))
+        write_a_record(output, 's1.' + site['name'], site.ipv4(index=2))
 
 
 def export_pcu_records(output, sites):
-  comment(output, 'pcus v4')
-  for site in sites:
-      # TODO: change site['nodes'] to a pre-sorted list type.
-      for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-          write_a_record(output, node['pcu'].recordname(), node['pcu'].ipv4())
+    comment(output, 'pcus v4')
+    for site in sites:
+        # TODO: change site['nodes'] to a pre-sorted list type.
+        for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+            write_a_record(output, node['pcu'].recordname(), node['pcu'].ipv4())
 
 
 def export_server_records(output, sites):
-  export_server_records_v4(output, sites)
-  export_server_records_v4(output, sites, decoration='v4')
-  export_server_records_v6(output, sites)
-  export_server_records_v6(output, sites, decoration='v6')
+    export_server_records_v4(output, sites)
+    export_server_records_v4(output, sites, decoration='v4')
+    export_server_records_v6(output, sites)
+    export_server_records_v6(output, sites, decoration='v6')
 
 
 def export_server_records_v4(output, sites, decoration=''):
-  comment(output, 'hosts v4%s' % (' decorated' if decoration else ''))
-  for site in sites:
-      # TODO: change site['nodes'] to a pre-sorted list type.
-      for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-          write_a_record(output, node.recordname(decoration), node.ipv4())
+    comment(output, 'hosts v4%s' % (' decorated' if decoration else ''))
+    for site in sites:
+        # TODO: change site['nodes'] to a pre-sorted list type.
+        for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+            write_a_record(output, node.recordname(decoration), node.ipv4())
 
 
 def export_server_records_v6(output, sites, decoration=''):
-  comment(output, 'hosts v6%s' % (' decorated' if decoration else ''))
-  for site in sites:
-      # TODO: change site['nodes'] to a pre-sorted list type.
-      for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-          if node.ipv6_is_enabled():
-              write_aaaa_record(
-                  output, node.recordname(decoration), node.ipv6())
+    comment(output, 'hosts v6%s' % (' decorated' if decoration else ''))
+    for site in sites:
+        # TODO: change site['nodes'] to a pre-sorted list type.
+        for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+            if node.ipv6_is_enabled():
+                write_aaaa_record(
+                    output, node.recordname(decoration), node.ipv6())
 
 
 def export_experiment_records(output, sites, experiments):
-  for experiment in experiments:
-    if experiment['index'] is None:
-      # Ignore experiments without an IP address.
-      continue
-    export_experiment_records_v4(output, sites, experiment)
-    export_experiment_records_v4(output, sites, experiment, decoration='v4')
+    for experiment in experiments:
+        if experiment['index'] is None:
+            # Ignore experiments without an IP address.
+            continue
+        export_experiment_records_v4(output, sites, experiment)
+        export_experiment_records_v4(output, sites, experiment, decoration='v4')
 
-    export_experiment_records_v6(output, sites, experiment)
-    export_experiment_records_v6(output, sites, experiment, decoration='v6')
+        export_experiment_records_v6(output, sites, experiment)
+        export_experiment_records_v6(output, sites, experiment, decoration='v6')
 
 
 def export_experiment_records_v4(output, sites, experiment, decoration=''):
-  comment(output, '%s v4%s' % (experiment.dnsname(), (
-      ' decorated' if decoration else '')))
-  for site in sites:
-    # TODO: change site['nodes'] to a pre-sorted list type.
-    for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-        # TODO: should sitenames exclude mlab4's?
-        write_a_record(output, experiment.sitename(node, decoration),
-                       experiment.ipv4(node))
-        write_a_record(output, experiment.recordname(node, decoration),
-                       experiment.ipv4(node))
+    comment(output, '%s v4%s' % (experiment.dnsname(), (
+        ' decorated' if decoration else '')))
+    for site in sites:
+        # TODO: change site['nodes'] to a pre-sorted list type.
+        for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+            # TODO: should sitenames exclude mlab4's?
+            write_a_record(output, experiment.sitename(node, decoration),
+                           experiment.ipv4(node))
+            write_a_record(output, experiment.recordname(node, decoration),
+                           experiment.ipv4(node))
 
 
 def export_experiment_records_v6(output, sites, experiment, decoration=''):
-  comment(output, '%s v6%s' % (experiment.dnsname(), (
-      ' decorated' if decoration else '')))
-  for site in sites:
-    # TODO: change site['nodes'] to a pre-sorted list type.
-    for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-      # TODO: should sitenames exclude mlab4's?
-      if (node.ipv6_is_enabled() and experiment.ipv6(node)):
-        write_aaaa_record(output, experiment.sitename(node, decoration),
-                          experiment.ipv6(node))
-        write_aaaa_record(output, experiment.recordname(node, decoration),
-                          experiment.ipv6(node))
+    comment(output, '%s v6%s' % (experiment.dnsname(), (
+        ' decorated' if decoration else '')))
+    for site in sites:
+        # TODO: change site['nodes'] to a pre-sorted list type.
+        for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+            # TODO: should sitenames exclude mlab4's?
+            if (node.ipv6_is_enabled() and experiment.ipv6(node)):
+                write_aaaa_record(output, experiment.sitename(node, decoration),
+                                  experiment.ipv6(node))
+                write_aaaa_record(output, experiment.recordname(
+                    node,decoration), experiment.ipv6(node))
 
 
 def export_mlab_zone_records(output, sites, experiments):

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -10,8 +10,8 @@ import time
 
 ZONE_TTL = 60 * 5
 ZONE_MIN_TTL = 60 * 5
-ZONE_REFRESH = 60 * 10
-ZONE_RETRY = 60 * 60
+ZONE_REFRESH = 60 * 60
+ZONE_RETRY = 60 * 10
 ZONE_EXPIRE = 7 * 60 * 60 * 24
 ZONE_HEADER_TEMPLATE = 'mlabzone.header.in'
 

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -279,7 +279,8 @@ def main():
         export_mlab_site_stats(sys.stdout, sites)
     elif options.format == 'zone':
         with open(options.zoneheader, 'r') as header:
-            options.serial = serial_rfc1912(time.gmtime())
+            if options.serial == 'auto':
+                options.serial = serial_rfc1912(time.gmtime())
             export_mlab_zone_header(sys.stdout, header, options)
             sys.stdout.write("\n\n")
             export_mlab_zone_records(sys.stdout, sites, experiments)

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -8,6 +8,13 @@ import StringIO
 import sys
 import time
 
+ZONE_TTL = 60 * 5
+ZONE_MIN_TTL = 60 * 5
+ZONE_REFRESH = 60 * 5
+ZONE_RETRY = 60 * 60
+ZONE_EXPIRE = 7 * 60 * 60 * 24
+ZONE_HEADER_TEMPLATE = 'mlabzone.header.in'
+
 
 def usage():
     return """
@@ -22,7 +29,6 @@ EXAMPLES:
     mlabconfig.py --format=sitestats
       (e.g. mlab-site-stats.json)
 
-TODO:
     mlabconfig.py --format=zone
       (e.g. gen_zones.py)
 """
@@ -30,6 +36,19 @@ TODO:
 
 def parse_flags():
     parser = optparse.OptionParser(usage=usage())
+    parser.set_defaults(force=False,
+                        support_email="support.measurementlab.net",
+                        primary_nameserver="ns.chambana.net",
+                        secondary_nameserver="sns-pb.isc.org",
+                        domain="measurement-lab.org",
+                        serial="auto",
+                        zonefile=None,
+                        ttl=ZONE_TTL,
+                        minttl=ZONE_MIN_TTL,
+                        refresh=ZONE_REFRESH,
+                        retry=ZONE_RETRY,
+                        expire=ZONE_EXPIRE)
+
     parser.add_option(
         '', '--sites_config', metavar='sites', dest='sites_config',
         default='sites', help='The name of the module with Site() definitions.')
@@ -45,11 +64,150 @@ def parse_flags():
         default='slice_list',
         help=('The variable name of experiments within the experiments_config '
               'data.'))
-    # TODO: Support multiple formats, e.g. 'hostips', 'zone', 'sitestats'.
     parser.add_option(
         '', '--format', metavar='format', dest='format', default='hostips',
         help='Format of output.')
+    parser.add_option(
+        '', '--zoneheader', metavar='zoneheader.in', dest='zoneheader',
+        default=ZONE_HEADER_TEMPLATE,
+        help='The full path to zone header file.')
     return parser.parse_args()
+
+
+def comment(output, note):
+    output.write('\n; %s\n' % note)
+
+
+def write_a_record(output, hostname, ipv4):
+    output.write(format_a_record(hostname, ipv4))
+    output.write('\n')
+
+
+def format_a_record(hostname, ipv4):
+    return '%-32s  IN  A   \t%s' % (hostname, ipv4)
+
+
+def write_aaaa_record(output, hostname, ipv6):
+    output.write(format_aaaa_record(hostname, ipv6))
+    output.write('\n')
+
+
+def format_aaaa_record(hostname, ipv6):
+    return '%-32s  IN  AAAA\t%s' % (hostname, ipv6)
+
+
+def export_router_and_switch_records(output, sites):
+  comment(output, 'router and switch v4 records.')
+  for i, site in enumerate(sites):
+      write_a_record(output, 'r1.' + site['name'], site.ipv4(index=1))
+      write_a_record(output, 's1.' + site['name'], site.ipv4(index=2))
+
+
+def export_pcu_records(output, sites):
+  comment(output, 'pcus v4')
+  for site in sites:
+      # TODO: change site['nodes'] to a pre-sorted list type.
+      for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+          write_a_record(output, node['pcu'].recordname(), node['pcu'].ipv4())
+
+
+def export_server_records(output, sites):
+  export_server_records_v4(output, sites)
+  export_server_records_v4(output, sites, decoration='v4')
+  export_server_records_v6(output, sites)
+  export_server_records_v6(output, sites, decoration='v6')
+
+
+def export_server_records_v4(output, sites, decoration=''):
+  comment(output, 'hosts v4%s' % (' decorated' if decoration else ''))
+  for site in sites:
+      # TODO: change site['nodes'] to a pre-sorted list type.
+      for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+          write_a_record(output, node.recordname(decoration), node.ipv4())
+
+
+def export_server_records_v6(output, sites, decoration=''):
+  comment(output, 'hosts v6%s' % (' decorated' if decoration else ''))
+  for site in sites:
+      # TODO: change site['nodes'] to a pre-sorted list type.
+      for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+          if node.ipv6_is_enabled():
+              write_aaaa_record(
+                  output, node.recordname(decoration), node.ipv6())
+
+
+def export_experiment_records(output, sites, experiments):
+  for experiment in experiments:
+    if experiment['index'] is None:
+      # Ignore experiments without an IP address.
+      continue
+    export_experiment_records_v4(output, sites, experiment)
+    export_experiment_records_v4(output, sites, experiment, decoration='v4')
+
+    export_experiment_records_v6(output, sites, experiment)
+    export_experiment_records_v6(output, sites, experiment, decoration='v6')
+
+
+def export_experiment_records_v4(output, sites, experiment, decoration=''):
+  comment(output, '%s v4%s' % (experiment.dnsname(), (
+      ' decorated' if decoration else '')))
+  for site in sites:
+    # TODO: change site['nodes'] to a pre-sorted list type.
+    for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+        # TODO: should sitenames exclude mlab4's?
+        write_a_record(output, experiment.sitename(node, decoration),
+                       experiment.ipv4(node))
+        write_a_record(output, experiment.recordname(node, decoration),
+                       experiment.ipv4(node))
+
+
+def export_experiment_records_v6(output, sites, experiment, decoration=''):
+  comment(output, '%s v6%s' % (experiment.dnsname(), (
+      ' decorated' if decoration else '')))
+  for site in sites:
+    # TODO: change site['nodes'] to a pre-sorted list type.
+    for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
+      # TODO: should sitenames exclude mlab4's?
+      if (node.ipv6_is_enabled() and experiment.ipv6(node)):
+        write_aaaa_record(output, experiment.sitename(node, decoration),
+                          experiment.ipv6(node))
+        write_aaaa_record(output, experiment.recordname(node, decoration),
+                          experiment.ipv6(node))
+
+
+def export_mlab_zone_records(output, sites, experiments):
+    export_router_and_switch_records(output, sites)
+    export_pcu_records(output, sites)
+    export_server_records(output, sites)
+    export_experiment_records(output, sites, experiments)
+
+
+def serial_rfc1912(ts):
+    """Returns an rfc1912 style serial id (YYYYMMDDnn) for a DNS zone file."""
+    # RFC1912 (http://www.ietf.org/rfc/rfc1912.txt) recommends 'nn' as the
+    # revision. However, identifying and incrementing this value is a manual,
+    # error prone step. Instead, the following calculates 'nn' from HH:MM (00:00
+    # to 23:59, or 0 to 1439) by calculating the corresponding value in the
+    # range 00 to 99. 'nn' increases by 1 about every 15 minutes.
+    serial_prefix = time.strftime('%Y%m%d', ts)
+    n = (ts.tm_hour * 60.0 + ts.tm_min) * 99.0 / 1439.0
+    return serial_prefix + ('%02d' % int(n))
+
+
+def export_mlab_zone_header(output, header, options):
+    """Writes the zone header file to output.
+
+    Data read from header is used as a template and populated with values from
+    options. The end result is written to output.
+
+    Args:
+        output: file, a file object open for writing.
+        header: file, a file object open for reading.
+        options: optparse.Values, all command line options.
+    """
+    headerdata = header.read()
+    headerdata = headerdata % options.__dict__
+    output.write(headerdata)
 
 
 def export_mlab_site_stats(output, sites):
@@ -111,8 +269,11 @@ def main():
     elif options.format == 'sitestats':
         export_mlab_site_stats(sys.stdout, sites)
     elif options.format == 'zone':
-        print 'Sorry, mlabconfig does not yet support generating zone files.'
-        sys.exit(1)
+        with open(options.zoneheader, 'r') as header:
+            options.serial = serial_rfc1912(time.gmtime())
+            export_mlab_zone_header(sys.stdout, header, options)
+            output.write("\n\n")
+            export_mlab_zone_records(sys.stdout, sites, experiments)
     else:
         print 'Sorry, unknown format: %s' % options.format
         sys.exit(1)

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -10,7 +10,7 @@ import time
 
 ZONE_TTL = 60 * 5
 ZONE_MIN_TTL = 60 * 5
-ZONE_REFRESH = 60 * 5
+ZONE_REFRESH = 60 * 10
 ZONE_RETRY = 60 * 60
 ZONE_EXPIRE = 7 * 60 * 60 * 24
 ZONE_HEADER_TEMPLATE = 'mlabzone.header.in'

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -164,7 +164,7 @@ def export_experiment_records_v4(output, sites, experiment, decoration=''):
     for site in sites:
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-            # TODO: should sitenames exclude mlab4's?
+            # TODO: remove sitenames (or exclude mlab4's).
             write_a_record(output, experiment.sitename(node, decoration),
                            experiment.ipv4(node))
             write_a_record(output, experiment.recordname(node, decoration),
@@ -177,7 +177,7 @@ def export_experiment_records_v6(output, sites, experiment, decoration=''):
     for site in sites:
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
-            # TODO: should sitenames exclude mlab4's?
+            # TODO: remove sitenames (or exclude mlab4's).
             if (node.ipv6_is_enabled() and experiment.ipv6(node)):
                 write_aaaa_record(output, experiment.sitename(node, decoration),
                                   experiment.ipv6(node))

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import json
+import logging
 import optparse
 import os
 import re
@@ -71,7 +72,15 @@ def parse_flags():
         '', '--zoneheader', metavar='zoneheader.in', dest='zoneheader',
         default=ZONE_HEADER_TEMPLATE,
         help='The full path to zone header file.')
-    return parser.parse_args()
+
+    (options, args) = parse_flags()
+
+    # Check given parameters.
+    if options.format == 'zone' and not os.path.exists(options.zoneheader):
+        logging.error('Zone header file %s not found!', options.zoneheader)
+        sys.exit(1)
+
+    return (options, args)
 
 
 def comment(output, note):
@@ -275,7 +284,7 @@ def main():
             sys.stdout.write("\n\n")
             export_mlab_zone_records(sys.stdout, sites, experiments)
     else:
-        print 'Sorry, unknown format: %s' % options.format
+        logging.error('Sorry, unknown format: %s', options.format)
         sys.exit(1)
 
 

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -38,8 +38,8 @@ def parse_flags():
     parser = optparse.OptionParser(usage=usage())
     parser.set_defaults(force=False,
                         support_email='support.measurementlab.net',
-                        primary_nameserver='ns.chambana.net',
-                        secondary_nameserver='sns-pb.isc.org',
+                        primary_nameserver='sns-pb.isc.org',
+                        secondary_nameserver='ns-mlab.greenhost.net',
                         domain='measurement-lab.org',
                         serial='auto',
                         zonefile=None,

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -272,7 +272,7 @@ def main():
         with open(options.zoneheader, 'r') as header:
             options.serial = serial_rfc1912(time.gmtime())
             export_mlab_zone_header(sys.stdout, header, options)
-            output.write("\n\n")
+            sys.stdout.write("\n\n")
             export_mlab_zone_records(sys.stdout, sites, experiments)
     else:
         print 'Sorry, unknown format: %s' % options.format

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -1,10 +1,12 @@
 """Tests for mlabconfig."""
 
-import mlabconfig
-import StringIO
-import unittest
-from planetlab import model
 import json
+import mlabconfig
+import optparse
+from planetlab import model
+import StringIO
+import time
+import unittest
 
 
 class MlabconfigTest(unittest.TestCase):
@@ -57,6 +59,96 @@ class MlabconfigTest(unittest.TestCase):
 
         results = json.loads(output.getvalue())
         self.assertItemsEqual(results, expected_results)
+
+    def test_export_router_and_switch_records(self):
+        output = StringIO.StringIO()
+        expected_results = [
+            mlabconfig.format_a_record('r1.abc01', '192.168.1.1'),
+            mlabconfig.format_a_record('s1.abc01', '192.168.1.2'),
+        ]
+
+        mlabconfig.export_router_and_switch_records(output, self.sites)
+
+        results = output.getvalue().split('\n')
+        self.assertContainsItems(results, expected_results)
+
+    def test_export_pcu_records(self):
+        output = StringIO.StringIO()
+        expected_results = [
+            mlabconfig.format_a_record('mlab1d.abc01', '192.168.1.4'),
+            mlabconfig.format_a_record('mlab2d.abc01', '192.168.1.5'),
+            mlabconfig.format_a_record('mlab3d.abc01', '192.168.1.6'),
+        ]
+
+        mlabconfig.export_pcu_records(output, self.sites)
+
+        results = output.getvalue().split('\n')
+        self.assertContainsItems(results, expected_results)
+
+    def test_export_server_records(self):
+        output = StringIO.StringIO()
+        # This is a subset of expected results.
+        expected_results = [
+            mlabconfig.format_a_record('mlab1.abc01', '192.168.1.9'),
+            mlabconfig.format_a_record('mlab2v4.abc01', '192.168.1.22'),
+            mlabconfig.format_aaaa_record('mlab3.abc01', '2400:1002:4008::35'),
+            mlabconfig.format_aaaa_record('mlab1v6.abc01', '2400:1002:4008::9')
+        ]
+
+        mlabconfig.export_server_records(output, self.sites)
+
+        results = output.getvalue().split('\n')
+        self.assertContainsItems(results, expected_results)
+
+    def test_export_experiment_records(self):
+        output = StringIO.StringIO()
+        experiments = [model.Slice(name='abc_bar', index=1, attrs=self.attrs,
+                                   users=self.users, use_initscript=True,
+                                   ipv6='all')]
+        expected_results = [
+            mlabconfig.format_a_record(
+                'bar.abc.abc01', '192.168.1.11'),
+            mlabconfig.format_a_record(
+                'bar.abc.mlab2.abc01', '192.168.1.24'),
+            mlabconfig.format_a_record(
+                'bar.abcv4.abc01', '192.168.1.11'),
+            mlabconfig.format_a_record(
+                'bar.abc.mlab2v4.abc01', '192.168.1.24'),
+            mlabconfig.format_aaaa_record(
+                'bar.abc.abc01', '2400:1002:4008::11'),
+            mlabconfig.format_aaaa_record(
+                'bar.abc.abc01', '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record(
+                'bar.abc.mlab3.abc01', '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record(
+                'bar.abcv6.abc01', '2400:1002:4008::11'),
+            mlabconfig.format_aaaa_record(
+                'bar.abc.mlab1v6.abc01', '2400:1002:4008::11'),
+        ]
+
+        mlabconfig.export_experiment_records(output, self.sites, experiments)
+
+        results = output.getvalue().split('\n')
+        self.assertContainsItems(results, expected_results)
+
+    def test_serial_rfc1912(self):
+        # Fri Oct 31 00:45:00 2015 UTC.
+        # 45-minutes should result in 03.
+        ts = 1446252300
+
+        serial = mlabconfig.serial_rfc1912(time.gmtime(ts))
+
+        self.assertEqual('2015103103', serial)
+
+    def test_export_mlab_zone_header(self):
+        options = optparse.Values()
+        options.value = 'middle'
+        output = StringIO.StringIO()
+        header = StringIO.StringIO('before; %(value)s; after')
+
+        mlabconfig.export_mlab_zone_header(output, header, options)
+
+        self.assertEqual(output.getvalue(), 'before; middle; after')
 
 
 if __name__ == '__main__':

--- a/plsync/mlabzone.header.in
+++ b/plsync/mlabzone.header.in
@@ -25,6 +25,7 @@ $TTL    %(ttl)s
 ;
 www     IN      A       128.112.139.90
 
+; TODO: can we retire DONAR?
 ; ---------- DONAR -------
 ;
 donar   IN      NS      utility.mlab.mlab1.lhr01.measurement-lab.org.

--- a/plsync/mlabzone.header.in
+++ b/plsync/mlabzone.header.in
@@ -1,0 +1,52 @@
+;
+; Primary DNS zone file
+; NOTE: this file was automatically generated!!!
+; NOTE: DO NOT EDIT
+;
+
+$ORIGIN %(domain)s.
+$TTL    %(ttl)s
+
+; @	    IN 	    SOA	    alfred.cs.princeton.edu. support.planet-lab.org. (
+; @       IN      NS      alfred.cs.princeton.edu.
+; @       IN      NS      sns-pb.isc.org.
+
+@       IN      SOA     %(primary_nameserver)s. %(support_email)s. (
+        %(serial)s      ; Serial
+        %(refresh)s     ; Refresh
+        %(retry)s       ; Retry
+        %(expire)s      ; Expire
+        %(minttl)s )    ; Negative caching TTL
+@       IN      NS      %(primary_nameserver)s.
+@       IN      NS      %(secondary_nameserver)s.
+
+; TODO: fix A and MX records appropriately.
+@       IN      A       128.112.139.90
+@       IN      MX 0    mail.planet-lab.org.
+*       IN      MX 0    mail.planet-lab.org.
+
+; ---------- WWW ----------
+;
+www     IN      A       128.112.139.90
+
+; ---------- DONAR -------
+;
+;donar   IN      NS      ns1.mlab.donardns.net.
+;donar   IN      NS      ns2.mlab.donardns.net.
+;donar   IN      NS      ns3.mlab.donardns.net.
+;donar   IN      NS      ns4.mlab.donardns.net.
+;donar   IN      NS      ns5.mlab.donardns.net.
+;donar   IN      NS      ns6.mlab.donardns.net.
+;donar   IN      NS      ns7.mlab.donardns.net.
+;donar   IN      NS      ns8.mlab.donardns.net.
+;donar   IN      NS      ns9.mlab.donardns.net.
+;donar   IN      NS      ns10.mlab.donardns.net.
+;donar   IN      NS      ns11.mlab.donardns.net.
+;donar   IN      NS      ns12.mlab.donardns.net.
+
+donar   IN      NS      utility.mlab.mlab1.lhr01.measurement-lab.org.
+donar   IN      NS      utility.mlab.mlab1.par01.measurement-lab.org.
+donar   IN      NS      utility.mlab.mlab1.lax01.measurement-lab.org.
+donar   IN      NS      utility.mlab.mlab1.lga01.measurement-lab.org.
+donar   IN      NS      utility.mlab.mlab1.syd01.measurement-lab.org.
+donar   IN      NS      utility.mlab.mlab1.hnd01.measurement-lab.org.

--- a/plsync/mlabzone.header.in
+++ b/plsync/mlabzone.header.in
@@ -7,10 +7,6 @@
 $ORIGIN %(domain)s.
 $TTL    %(ttl)s
 
-; @	    IN 	    SOA	    alfred.cs.princeton.edu. support.planet-lab.org. (
-; @       IN      NS      alfred.cs.princeton.edu.
-; @       IN      NS      sns-pb.isc.org.
-
 @       IN      SOA     %(primary_nameserver)s. %(support_email)s. (
         %(serial)s      ; Serial
         %(refresh)s     ; Refresh
@@ -31,19 +27,6 @@ www     IN      A       128.112.139.90
 
 ; ---------- DONAR -------
 ;
-;donar   IN      NS      ns1.mlab.donardns.net.
-;donar   IN      NS      ns2.mlab.donardns.net.
-;donar   IN      NS      ns3.mlab.donardns.net.
-;donar   IN      NS      ns4.mlab.donardns.net.
-;donar   IN      NS      ns5.mlab.donardns.net.
-;donar   IN      NS      ns6.mlab.donardns.net.
-;donar   IN      NS      ns7.mlab.donardns.net.
-;donar   IN      NS      ns8.mlab.donardns.net.
-;donar   IN      NS      ns9.mlab.donardns.net.
-;donar   IN      NS      ns10.mlab.donardns.net.
-;donar   IN      NS      ns11.mlab.donardns.net.
-;donar   IN      NS      ns12.mlab.donardns.net.
-
 donar   IN      NS      utility.mlab.mlab1.lhr01.measurement-lab.org.
 donar   IN      NS      utility.mlab.mlab1.par01.measurement-lab.org.
 donar   IN      NS      utility.mlab.mlab1.lax01.measurement-lab.org.


### PR DESCRIPTION
This change adds a new output format for mlabconfig to generate a zone file for measurement-lab.org. This form of generation should obsolete gen-zone.py.

The mlabzone.header.in is taken from the current gen-zone.py script. The included version of mlabzone.header.in increases the zone expiration time from 1 day to 7 days. This should allow for longer periods of outages of the shadow master server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/39)
<!-- Reviewable:end -->
