### PR TITLE
Add pboothe temporarily for testing

### DIFF
--- a/plsync/users.py
+++ b/plsync/users.py
@@ -7,5 +7,5 @@ user_list = [('Stephen', 'Stuart', 'sstuart@google.com'),
              ('Josh',    'Bailey', 'joshb@google.com'),
              ('Steph', 'Alarcon', 'salarcon@measurementlab.net'),
              ('Nathan', 'Kinkade', 'kinkade@opentechinstitute.org'),
-             ('Matt', 'Mathis', 'mattmathis@google.com')
+             ('Matt', 'Mathis', 'mattmathis@google.com'),
              ('Peter', 'Boothe', 'pboothe@google.com')]

--- a/plsync/users.py
+++ b/plsync/users.py
@@ -7,4 +7,5 @@ user_list = [('Stephen', 'Stuart', 'sstuart@google.com'),
              ('Josh',    'Bailey', 'joshb@google.com'),
              ('Steph', 'Alarcon', 'salarcon@measurementlab.net'),
              ('Nathan', 'Kinkade', 'kinkade@opentechinstitute.org'),
-             ('Matt', 'Mathis', 'mattmathis@google.com')]
+             ('Matt', 'Mathis', 'mattmathis@google.com')
+             ('Peter', 'Boothe', 'pboothe@google.com')]


### PR DESCRIPTION
This is to give Peter access to all systems for testing NDT-SSL. We gave him access to a test site but nodebase (correctly) deletes his key after a time, leaving him without access unless he keeps an open connection. Further, he wants the ability to look at logs across the fleet as the change is pushed out.