### PR TITLE
Disable IPv6 for production servers until ndt server fixes are in

### DIFF
--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -90,9 +90,7 @@ slice_list = [
                                                 Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ], 
                                            users=user_list,
                                            use_initscript=True,
-                                           ipv6=['mlab1.nuq1t', 'mlab2.nuq1t', 'mlab3.nuq1t', 'mlab4.nuq1t',
-                                                 'mlab1.nuq02', 'mlab2.nuq02', 'mlab3.nuq02',
-                                                 'mlab1.lga06', 'mlab2.lga06', 'mlab3.lga06', 'mlab4.lga06']),
+                                           ipv6=['mlab1.nuq1t', 'mlab2.nuq1t', 'mlab3.nuq1t', 'mlab4.nuq1t']),
     Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+web100_enable_attr+[
                                                 Attr('MeasurementLabCentos',    disk_max='10000000'),
                                                 Attr(None,    vsys='web100_proc_write'), ],


### PR DESCRIPTION
This change disables the ipv6 configuration on production NDT servers
until the known issues related to IPv6 support are resolved.

Known issues include - https://github.com/m-lab/ndt/issues/24
 * crash on failed reverse lookup of IPv6 client addresses.
 * incorrectly logging LocalAddress "::" or local_ip as 0.0.0.0 for an IPv6 client.

When these are fixed, or verified to work on test servers, we can
re-enable IPv6 for production servers.