### PR TITLE
Added ath03 site

### DIFF
--- a/plsync/sites.py
+++ b/plsync/sites.py
@@ -83,6 +83,7 @@ site_list = [
     makesite('atl05','67.106.215.192', '2610:0018:0111:C002::','Atlanta_GA', 'US', 33.636700, -84.428100, user_list, count=4, arch='x86_64', nodegroup='MeasurementLabCentos'),
     makesite('ath01','83.212.4.0',     '2001:648:2ffc:2101::', 'Athens', 'GR', 37.936400, 23.944400, user_list, nodegroup='MeasurementLabCentos'),
     makesite('ath02','83.212.5.128',   '2001:648:2ffc:2102::', 'Athens', 'GR', 37.936400, 23.944400, user_list, nodegroup='MeasurementLabCentos'),
+    makesite('ath03','193.201.166.128',   '2001:648:25e0::', 'Athens', 'GR', 37.936400, 23.944400, user_list, count=4, v6gw=2001:648:25e0::129 nodegroup='MeasurementLabCentos'),
     makesite('beg01','188.120.127.0',  '2001:7f8:1e:6::',      'Belgrade', 'RS', 44.821600, 20.292100, user_list, nodegroup='MeasurementLabCentos'),
     makesite('bkk01','61.7.252.0',     '2001:c38:9041::',      'Bangkok', 'TH', 13.690400, 100.750100, user_list, arch='x86_64', nodegroup='MeasurementLabCentos'),
     makesite('bog01','190.15.11.0',    None,                   'Bogota', 'CO', 4.5833, -74.066700, user_list, exclude=[1,2,3], nodegroup='MeasurementLabCentos'),

--- a/plsync/sites.py
+++ b/plsync/sites.py
@@ -83,7 +83,7 @@ site_list = [
     makesite('atl05','67.106.215.192', '2610:0018:0111:C002::','Atlanta_GA', 'US', 33.636700, -84.428100, user_list, count=4, arch='x86_64', nodegroup='MeasurementLabCentos'),
     makesite('ath01','83.212.4.0',     '2001:648:2ffc:2101::', 'Athens', 'GR', 37.936400, 23.944400, user_list, nodegroup='MeasurementLabCentos'),
     makesite('ath02','83.212.5.128',   '2001:648:2ffc:2102::', 'Athens', 'GR', 37.936400, 23.944400, user_list, nodegroup='MeasurementLabCentos'),
-    makesite('ath03','193.201.166.128',   '2001:648:25e0::', 'Athens', 'GR', 37.936400, 23.944400, user_list, count=4, v6gw=2001:648:25e0::129 nodegroup='MeasurementLabCentos'),
+    makesite('ath03','193.201.166.128', '2001:648:25e0::',     'Athens', 'GR', 37.936400, 23.944400, user_list, count=4, v6gw=2001:648:25e0::129 nodegroup='MeasurementLabCentos'),
     makesite('beg01','188.120.127.0',  '2001:7f8:1e:6::',      'Belgrade', 'RS', 44.821600, 20.292100, user_list, nodegroup='MeasurementLabCentos'),
     makesite('bkk01','61.7.252.0',     '2001:c38:9041::',      'Bangkok', 'TH', 13.690400, 100.750100, user_list, arch='x86_64', nodegroup='MeasurementLabCentos'),
     makesite('bog01','190.15.11.0',    None,                   'Bogota', 'CO', 4.5833, -74.066700, user_list, exclude=[1,2,3], nodegroup='MeasurementLabCentos'),


### PR DESCRIPTION
Added a line for the new Athens site. Kostas specified the IPv4 network as 193.201.166.128/26 and the IPv6 gw as "2001:648:25e0::129/64". They are reflected in this change. StephenZ noted by email that when in IPv6 gateway is ":129" rather than ":1", it should be specified with  "v6gw". See nuq01 for an example.