### PR TITLE
Apparently sites without IPv6 support require the exclude=[1,2,3] parameter.

### DIFF
--- a/plsync/sites.py
+++ b/plsync/sites.py
@@ -152,7 +152,7 @@ site_list = [
     makesite('svg01','81.167.39.0',    '2a01:798:0:13::',      'Stavanger', 'NO', 58.876700, 5.63780, user_list, nodegroup='MeasurementLabCentos'),
     makesite('syd01','203.5.76.128',   '2001:388:00d0::',      'Sydney', 'AU', -33.946100, 151.177000, user_list, nodegroup='MeasurementLabCentos'),
     makesite('syd02','175.45.79.0',    '2402:7800:0:12::',     'Sydney', 'AU', -33.946100, 151.177000, user_list, nodegroup='MeasurementLabCentos'),
-    makesite('tnr01','41.188.12.64',   None,                   'Antananarivo', 'MG', -18.7969, 47.4788, user_list, arch='x86_64', nodegroup='MeasurementLabCentos'),
+    makesite('tnr01','41.188.12.64',   None,                   'Antananarivo', 'MG', -18.7969, 47.4788, user_list, exclude=[1,2,3], arch='x86_64', nodegroup='MeasurementLabCentos'),
     makesite('tpe01','163.22.28.0',    '2001:e10:6840:28::',   'Taipei', 'TW', 25.077800, 121.224000, user_list, nodegroup='MeasurementLabCentos'),
     makesite('trn01','194.116.85.192', '2001:7F8:23:307::',    'Turin', 'IT', 45.200800, 7.649720, user_list, nodegroup='MeasurementLabCentos'),
     # old ipv6 2c0f:fab0:ffff:1000:: @ tun01


### PR DESCRIPTION
Michael from PlanetLab tried to add the new TNR01 site to the PLC database, but it failed, and he deduced that since this site has no IPv6 that the parameter _exclude[1,2,3]_ needed to be included.  He added it manually and successfully added the site, and this just brings the sites.py file up to date.