### PR TITLE
Changes arch to x86_64-r630, a new PLC arch tag value for the R630s

### DIFF
--- a/plsync/sites.py
+++ b/plsync/sites.py
@@ -156,7 +156,7 @@ site_list = [
     makesite('nuq0t','23.228.128.0',   '2605:a601:f1ff:fffd::', None, None, 0,0, user_list, count=4, nodegroup='MeasurementLabCentos'),
     makesite('nuq1t','23.228.128.128', '2605:a601:f1ff:ffff::','San Francisco Bay Area_CA', 'US', 37.383300, -122.066700, user_list, count=4, nodegroup='MeasurementLabCentos'),
     makesite('iad0t','165.117.251.128', None,'Washington_DC', 'US', 38.944400, -77.455800, user_list, count=4, exclude=[1,2,3,4], arch='x86_64', nodegroup='MeasurementLabCentos'),
-    makesite('iad1t','165.117.240.0', None,'Washington_DC', 'US', 38.944400, -77.455800, user_list, count=4, exclude=[1,2,3,4], arch='x86_64', nodegroup='MeasurementLabCentos'),
+    makesite('iad1t','165.117.240.0', None,'Washington_DC', 'US', 38.944400, -77.455800, user_list, count=4, exclude=[1,2,3,4], arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
    # NOTE: mlc servers need special handling
    #Site(name='mlc',   net=Network(v4='64.9.225.64',     v6='2604:CA00:F000:5::'), domain="measurementlab.net", count=3),
 ]


### PR DESCRIPTION
The new R630 hardware we are evaluating requires a few special kernel boot parameters in order to expose all the underlying hardware properly.  Specifically, "noapic acpi=off".  In order to make sure that other nodes don't also get these kernel parameters, arch will be set to x86_64-r630 for all R630-based site. Somehow PLC uses this tag value to manage each machine class a bit differently.... others are x86, x86_64, x86_64-r420, etc.