### PR TITLE
Remove model.py's dependency on planetlab/session.py

### DIFF
--- a/plsync/planetlab/sync.py
+++ b/plsync/planetlab/sync.py
@@ -891,7 +891,7 @@ def SyncSlice(sslice, hostname_or_site, addwhitelist, addsliceips, addusers,
     for h,node in sslice['network_list']:
         if (hostname_or_site is None or
             hostname_or_site == h or
-            hostname_or_site in h ):
+            hostname_or_site in h):
             if addwhitelist:
                 # Add this slice to the whitelist of all hosts.
                 WhitelistSliceOnNode(sslice['name'], h)

--- a/plsync/plsync.py
+++ b/plsync/plsync.py
@@ -2,6 +2,7 @@
 
 import pprint
 from planetlab import session
+from planetlab import sync
 import sys
 
 def usage():
@@ -225,12 +226,9 @@ def main():
             if (options.syncsite == "all" or 
                 options.syncsite == site['name']):
                 print "Syncing: site", site['name']
-                site.sync(options.ondest,
-                          options.addusers,
-                          options.addnodes,
-                          options.addinterfaces,
-                          options.getbootimages,
-                          options.createusers)
+                sync.SyncSite(site, options.ondest, options.addusers,
+                              options.addnodes, options.addinterfaces,
+                              options.getbootimages, options.createusers)
 
     elif options.syncslice is not None and options.syncsite is None:
         print options.syncslice
@@ -238,11 +236,9 @@ def main():
             if (options.syncslice == "all" or 
                 options.syncslice == sslice['name']):
                 print "Syncing: slice", sslice['name']
-                sslice.sync(options.ondest,
-                            options.addwhitelist,
-                            options.addsliceips,
-                            options.addusers,
-                            options.createslice)
+                sync.SyncSlice(sslice, options.ondest, options.addwhitelist,
+                               options.addsliceips, options.addusers,
+                               options.createslice)
 
     else:
         print usage()


### PR DESCRIPTION
This change removes the dependency model.py has on planetlab/session.py by moving class methods 'sync' from the model definitions of Site, Node, and Slice to functions in sync.py.

The original code is severely lacking consistency with M-Lab's current code quality and style and should be revised in a future change. This change performs the minimal updates to move code from "A" to "B".

The original functionality should be preserved.