### PR TITLE
Apply yapf python auto-formatting to mlabconfig.py and tests.

### DIFF
--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -51,28 +51,45 @@ def parse_flags():
                         retry=ZONE_RETRY,
                         expire=ZONE_EXPIRE)
 
+    parser.add_option('',
+                      '--sites_config',
+                      metavar='sites',
+                      dest='sites_config',
+                      default='sites',
+                      help='The name of the module with Site() definitions.')
+    parser.add_option('',
+                      '--experiments_config',
+                      metavar='slices',
+                      dest='experiments_config',
+                      default='slices',
+                      help='The name of the module with Slice() definitions.')
     parser.add_option(
-        '', '--sites_config', metavar='sites', dest='sites_config',
-        default='sites', help='The name of the module with Site() definitions.')
-    parser.add_option(
-        '', '--experiments_config', metavar='slices', dest='experiments_config',
-        default='slices',
-        help='The name of the module with Slice() definitions.')
-    parser.add_option(
-        '', '--sites', metavar='sites', dest='sites', default='site_list',
+        '',
+        '--sites',
+        metavar='sites',
+        dest='sites',
+        default='site_list',
         help='The variable name of sites within the sites_config data.')
     parser.add_option(
-        '', '--experiments', metavar='experiments', dest='experiments',
+        '',
+        '--experiments',
+        metavar='experiments',
+        dest='experiments',
         default='slice_list',
         help=('The variable name of experiments within the experiments_config '
               'data.'))
-    parser.add_option(
-        '', '--format', metavar='format', dest='format', default='hostips',
-        help='Format of output.')
-    parser.add_option(
-        '', '--zoneheader', metavar='zoneheader.in', dest='zoneheader',
-        default=ZONE_HEADER_TEMPLATE,
-        help='The full path to zone header file.')
+    parser.add_option('',
+                      '--format',
+                      metavar='format',
+                      dest='format',
+                      default='hostips',
+                      help='Format of output.')
+    parser.add_option('',
+                      '--zoneheader',
+                      metavar='zoneheader.in',
+                      dest='zoneheader',
+                      default=ZONE_HEADER_TEMPLATE,
+                      help='The full path to zone header file.')
 
     (options, args) = parse_flags()
 
@@ -142,8 +159,8 @@ def export_server_records_v6(output, sites, decoration=''):
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
             if node.ipv6_is_enabled():
-                write_aaaa_record(
-                    output, node.recordname(decoration), node.ipv6())
+                write_aaaa_record(output, node.recordname(decoration),
+                                  node.ipv6())
 
 
 def export_experiment_records(output, sites, experiments):
@@ -159,8 +176,8 @@ def export_experiment_records(output, sites, experiments):
 
 
 def export_experiment_records_v4(output, sites, experiment, decoration=''):
-    comment(output, '%s v4%s' % (experiment.dnsname(), (
-        ' decorated' if decoration else '')))
+    comment(output, '%s v4%s' % (experiment.dnsname(), (' decorated' if
+                                                        decoration else '')))
     for site in sites:
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
@@ -172,8 +189,8 @@ def export_experiment_records_v4(output, sites, experiment, decoration=''):
 
 
 def export_experiment_records_v6(output, sites, experiment, decoration=''):
-    comment(output, '%s v6%s' % (experiment.dnsname(), (
-        ' decorated' if decoration else '')))
+    comment(output, '%s v6%s' % (experiment.dnsname(), (' decorated' if
+                                                        decoration else '')))
     for site in sites:
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
@@ -181,8 +198,9 @@ def export_experiment_records_v6(output, sites, experiment, decoration=''):
             if (node.ipv6_is_enabled() and experiment.ipv6(node)):
                 write_aaaa_record(output, experiment.sitename(node, decoration),
                                   experiment.ipv6(node))
-                write_aaaa_record(output, experiment.recordname(
-                    node,decoration), experiment.ipv6(node))
+                write_aaaa_record(output, experiment.recordname(node,
+                                                                decoration),
+                                  experiment.ipv6(node))
 
 
 def export_mlab_zone_records(output, sites, experiments):
@@ -265,7 +283,11 @@ def export_mlab_site_stats(output, sites):
         location = site['location']
         if location is None:
             location = {
-                'city': '', 'country': '', 'latitude': None, 'longitude': None}
+                'city': '',
+                'country': '',
+                'latitude': None,
+                'longitude': None
+            }
         metro = [name, name[:-2]]
         sitestats.append({
             'site': name,
@@ -273,7 +295,8 @@ def export_mlab_site_stats(output, sites):
             'city': location['city'],
             'country': location['country'],
             'latitude': location['latitude'],
-            'longitude': location['longitude']})
+            'longitude': location['longitude']
+        })
     json.dump(sitestats, output)
 
 
@@ -283,8 +306,9 @@ def export_mlab_host_ips(output, sites, experiments):
     for site in sites:
         # TODO(soltesz): change 'nodes' to be a sorted list of node objects.
         for _, node in site['nodes'].iteritems():
-            output.write('{name},{ipv4},{ipv6}\n'.format(
-                name=node.hostname(), ipv4=node.ipv4(), ipv6=node.ipv6()))
+            output.write('{name},{ipv4},{ipv6}\n'.format(name=node.hostname(),
+                                                         ipv4=node.ipv4(),
+                                                         ipv6=node.ipv6()))
 
     # Export experiment names and addresses.
     for experiment in experiments:
@@ -293,9 +317,10 @@ def export_mlab_host_ips(output, sites, experiments):
             if experiment['index'] is None:
                 # Ignore experiments without an IP address.
                 continue
-            output.write('{name},{ipv4},{ipv6}\n'.format(
-                name=experiment.hostname(node), ipv4=experiment.ipv4(node),
-                ipv6=experiment.ipv6(node)))
+            output.write(
+                '{name},{ipv4},{ipv6}\n'.format(name=experiment.hostname(node),
+                                                ipv4=experiment.ipv4(node),
+                                                ipv6=experiment.ipv6(node)))
 
 
 def main():

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -14,11 +14,17 @@ import unittest
 class MlabconfigTest(unittest.TestCase):
 
     def setUp(self):
-      self.users = [('User', 'Name', 'username@gmail.com')]
-      self.sites = [model.makesite(
-          'abc01', '192.168.1.0', '2400:1002:4008::', 'Some City', 'US',
-          36.850000, 74.783000, self.users, nodegroup='MeasurementLabCentos')]
-      self.attrs = [model.Attr('MeasurementLabCentos', disk_max='60000000')]
+        self.users = [('User', 'Name', 'username@gmail.com')]
+        self.sites = [model.makesite('abc01',
+                                     '192.168.1.0',
+                                     '2400:1002:4008::',
+                                     'Some City',
+                                     'US',
+                                     36.850000,
+                                     74.783000,
+                                     self.users,
+                                     nodegroup='MeasurementLabCentos')]
+        self.attrs = [model.Attr('MeasurementLabCentos', disk_max='60000000')]
 
     def assertContainsItems(self, results, expected_items):
         """Asserts that every element of expected is present in results."""
@@ -27,8 +33,11 @@ class MlabconfigTest(unittest.TestCase):
 
     def test_export_mlab_host_ips(self):
         # Setup synthetic user, site, and experiment configuration data.
-        experiments = [model.Slice(name='abc_bar', index=1, attrs=self.attrs,
-                                   users=self.users, use_initscript=True,
+        experiments = [model.Slice(name='abc_bar',
+                                   index=1,
+                                   attrs=self.attrs,
+                                   users=self.users,
+                                   use_initscript=True,
                                    ipv6='all')]
         # Assign experiments to nodes.
         for hostname, node in self.sites[0]['nodes'].iteritems():
@@ -53,9 +62,12 @@ class MlabconfigTest(unittest.TestCase):
 
     def test_export_mlab_site_stats(self):
         output = StringIO.StringIO()
-        expected_results = [{"city": "Some City", "metro": ["abc01", "abc"],
-                             "country": "US", "site": "abc01",
-                             "longitude": 74.783, "latitude": 36.85}]
+        expected_results = [{"city": "Some City",
+                             "metro": ["abc01", "abc"],
+                             "country": "US",
+                             "site": "abc01",
+                             "longitude": 74.783,
+                             "latitude": 36.85}]
 
         mlabconfig.export_mlab_site_stats(output, self.sites)
 
@@ -104,28 +116,27 @@ class MlabconfigTest(unittest.TestCase):
 
     def test_export_experiment_records(self):
         output = StringIO.StringIO()
-        experiments = [model.Slice(name='abc_bar', index=1, attrs=self.attrs,
-                                   users=self.users, use_initscript=True,
+        experiments = [model.Slice(name='abc_bar',
+                                   index=1,
+                                   attrs=self.attrs,
+                                   users=self.users,
+                                   use_initscript=True,
                                    ipv6='all')]
         expected_results = [
-            mlabconfig.format_a_record(
-                'bar.abc.abc01', '192.168.1.11'),
-            mlabconfig.format_a_record(
-                'bar.abc.mlab2.abc01', '192.168.1.24'),
-            mlabconfig.format_a_record(
-                'bar.abcv4.abc01', '192.168.1.11'),
-            mlabconfig.format_a_record(
-                'bar.abc.mlab2v4.abc01', '192.168.1.24'),
-            mlabconfig.format_aaaa_record(
-                'bar.abc.abc01', '2400:1002:4008::11'),
-            mlabconfig.format_aaaa_record(
-                'bar.abc.abc01', '2400:1002:4008::37'),
-            mlabconfig.format_aaaa_record(
-                'bar.abc.mlab3.abc01', '2400:1002:4008::37'),
-            mlabconfig.format_aaaa_record(
-                'bar.abcv6.abc01', '2400:1002:4008::11'),
-            mlabconfig.format_aaaa_record(
-                'bar.abc.mlab1v6.abc01', '2400:1002:4008::11'),
+            mlabconfig.format_a_record('bar.abc.abc01', '192.168.1.11'),
+            mlabconfig.format_a_record('bar.abc.mlab2.abc01', '192.168.1.24'),
+            mlabconfig.format_a_record('bar.abcv4.abc01', '192.168.1.11'),
+            mlabconfig.format_a_record('bar.abc.mlab2v4.abc01', '192.168.1.24'),
+            mlabconfig.format_aaaa_record('bar.abc.abc01',
+                                          '2400:1002:4008::11'),
+            mlabconfig.format_aaaa_record('bar.abc.abc01',
+                                          '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record('bar.abc.mlab3.abc01',
+                                          '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record('bar.abcv6.abc01',
+                                          '2400:1002:4008::11'),
+            mlabconfig.format_aaaa_record('bar.abc.mlab1v6.abc01',
+                                          '2400:1002:4008::11'),
         ]
 
         mlabconfig.export_experiment_records(output, self.sites, experiments)
@@ -147,7 +158,7 @@ class MlabconfigTest(unittest.TestCase):
     @mock.patch.object(os.path, 'exists')
     @mock.patch('__builtin__.open')
     def test_get_revision_when_saved_prefix_is_old_and_revision_is_reset(
-        self, mopen, mock_exists):
+            self, mopen, mock_exists):
         prefix = '20151031'
         # All open and disk I/O is mocked out.
         # Pretend the file exists already.
@@ -170,8 +181,8 @@ class MlabconfigTest(unittest.TestCase):
 
     @mock.patch.object(os.path, 'exists')
     @mock.patch('__builtin__.open')
-    def test_get_revision_when_file_exists_increments_revision(
-        self, mopen, mock_exists):
+    def test_get_revision_when_file_exists_increments_revision(self, mopen,
+                                                               mock_exists):
         prefix = '20151031'
         # All open and disk I/O is mocked out.
         # Pretend the file exists already.
@@ -194,7 +205,7 @@ class MlabconfigTest(unittest.TestCase):
     @mock.patch.object(os.path, 'exists')
     @mock.patch('__builtin__.open')
     def test_get_revision_when_file_is_corrupt_default_values_saved(
-        self, mopen, mock_exists):
+            self, mopen, mock_exists):
         prefix = '20151031'
         # All open and disk I/O is mocked out.
         # Pretend the file exists already.
@@ -203,8 +214,7 @@ class MlabconfigTest(unittest.TestCase):
         mock_writer = mock.mock_open()
         # Open is called twice, once to read, and then to write.
         mopen.side_effect = [
-            mock.mock_open(
-                read_data='THIS IS NOT JSON').return_value,
+            mock.mock_open(read_data='THIS IS NOT JSON').return_value,
             mock_writer.return_value
         ]
 


### PR DESCRIPTION
The only changes in this PR is the result of `yapf` auto formatting on mlabconfig.py and tests.