### PR TITLE
Add "flattened" domain names so NDT SSL cert wildcard matching works

### DIFF
--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -130,7 +130,7 @@ def flatten_hostname(hostname):
     For example, convert 'ndt.iupui.mlab1.nuq1t' to 'ndt-iupui-mlab1-nuq1t'
 
     Args:
-      str, the dotted subdomain to flatten
+      hostname: str, the dotted subdomain to flatten
 
     Returns:
       str, the modified hostname

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -16,6 +16,7 @@ ZONE_RETRY = 60 * 10
 ZONE_EXPIRE = 7 * 60 * 60 * 24
 ZONE_HEADER_TEMPLATE = 'mlabzone.header.in'
 ZONE_SERIAL_COUNTER = '/tmp/mlabconfig.serial'
+SSL_EXPERIMENTS = ['iupui_ndt']
 
 
 def usage():
@@ -123,6 +124,20 @@ def format_aaaa_record(hostname, ipv6):
     return '%-32s  IN  AAAA\t%s' % (hostname, ipv6)
 
 
+def flatten_hostname(hostname):
+    """Converts subdomains to flat names suitable for SSL certificate wildcards.
+
+    For example, convert 'ndt.iupui.mlab1.nuq1t' to 'ndt-iupui-mlab1-nuq1t'
+
+    Args:
+      str, the dotted subdomain to flatten
+
+    Returns:
+      str, the modified hostname
+    """
+    return hostname.replace('.', '-')
+
+
 def export_router_and_switch_records(output, sites):
     comment(output, 'router and switch v4 records.')
     for i, site in enumerate(sites):
@@ -174,33 +189,64 @@ def export_experiment_records(output, sites, experiments):
         export_experiment_records_v6(output, sites, experiment)
         export_experiment_records_v6(output, sites, experiment, decoration='v6')
 
+        # Create "flattened" domain names for SSL enabled experiments so that
+        # certificate wildcard matching works. See flatten_hostname().
+        if experiment['name'] in SSL_EXPERIMENTS:
+            export_experiment_records_v4(
+                output, sites, experiment, decoration='', flatnames=True)
+            export_experiment_records_v4(
+                output, sites, experiment, decoration='v4', flatnames=True)
+            export_experiment_records_v6(
+                output, sites, experiment, decoration='', flatnames=True)
+            export_experiment_records_v6(
+                output, sites, experiment, decoration='v6', flatnames=True)
 
-def export_experiment_records_v4(output, sites, experiment, decoration=''):
-    comment(output, '%s v4%s' % (experiment.dnsname(), (' decorated' if
-                                                        decoration else '')))
+
+def export_experiment_records_v4(output,
+                                 sites,
+                                 experiment,
+                                 decoration='',
+                                 flatnames=False):
+    comment(output, '%s v4%s%s' % (experiment.dnsname(), (
+        ' decorated' if decoration else ''), (' flattened'
+                                              if flatnames else '')))
     for site in sites:
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
             # TODO: remove sitenames (or exclude mlab4's).
-            write_a_record(output, experiment.sitename(node, decoration),
-                           experiment.ipv4(node))
-            write_a_record(output, experiment.recordname(node, decoration),
-                           experiment.ipv4(node))
+            sitename = experiment.sitename(node, decoration)
+            recordname = experiment.recordname(node, decoration)
+
+            if flatnames:
+                sitename = flatten_hostname(sitename)
+                recordname = flatten_hostname(recordname)
+
+            write_a_record(output, sitename, experiment.ipv4(node))
+            write_a_record(output, recordname, experiment.ipv4(node))
 
 
-def export_experiment_records_v6(output, sites, experiment, decoration=''):
-    comment(output, '%s v6%s' % (experiment.dnsname(), (' decorated' if
-                                                        decoration else '')))
+def export_experiment_records_v6(output,
+                                 sites,
+                                 experiment,
+                                 decoration='',
+                                 flatnames=False):
+    comment(output, '%s v6%s%s' % (experiment.dnsname(), (
+        ' decorated' if decoration else ''), (' flattened'
+                                              if flatnames else '')))
     for site in sites:
         # TODO: change site['nodes'] to a pre-sorted list type.
         for node in sorted(site['nodes'].values(), key=lambda n: n.hostname()):
             # TODO: remove sitenames (or exclude mlab4's).
             if (node.ipv6_is_enabled() and experiment.ipv6(node)):
-                write_aaaa_record(output, experiment.sitename(node, decoration),
-                                  experiment.ipv6(node))
-                write_aaaa_record(output, experiment.recordname(node,
-                                                                decoration),
-                                  experiment.ipv6(node))
+                sitename = experiment.sitename(node, decoration)
+                recordname = experiment.recordname(node, decoration)
+
+                if flatnames:
+                    sitename = flatten_hostname(sitename)
+                    recordname = flatten_hostname(recordname)
+
+                write_aaaa_record(output, sitename, experiment.ipv6(node))
+                write_aaaa_record(output, recordname, experiment.ipv6(node))
 
 
 def export_mlab_zone_records(output, sites, experiments):

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -216,13 +216,12 @@ def export_experiment_records_v4(output,
             # TODO: remove sitenames (or exclude mlab4's).
             sitename = experiment.sitename(node, decoration)
             recordname = experiment.recordname(node, decoration)
-
             if flatnames:
-                sitename = flatten_hostname(sitename)
-                recordname = flatten_hostname(recordname)
-
-            write_a_record(output, sitename, experiment.ipv4(node))
-            write_a_record(output, recordname, experiment.ipv4(node))
+                write_a_record(output, flatten_hostname(recordname),
+                               experiment.ipv4(node))
+            else:
+                write_a_record(output, sitename, experiment.ipv4(node))
+                write_a_record(output, recordname, experiment.ipv4(node))
 
 
 def export_experiment_records_v6(output,
@@ -240,13 +239,12 @@ def export_experiment_records_v6(output,
             if (node.ipv6_is_enabled() and experiment.ipv6(node)):
                 sitename = experiment.sitename(node, decoration)
                 recordname = experiment.recordname(node, decoration)
-
                 if flatnames:
-                    sitename = flatten_hostname(sitename)
-                    recordname = flatten_hostname(recordname)
-
-                write_aaaa_record(output, sitename, experiment.ipv6(node))
-                write_aaaa_record(output, recordname, experiment.ipv6(node))
+                    write_aaaa_record(output, flatten_hostname(recordname),
+                                      experiment.ipv6(node))
+                else:
+                    write_aaaa_record(output, sitename, experiment.ipv6(node))
+                    write_aaaa_record(output, recordname, experiment.ipv6(node))
 
 
 def export_mlab_zone_records(output, sites, experiments):

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -179,6 +179,13 @@ class MlabconfigTest(unittest.TestCase):
         mlabconfig.export_experiment_records(output, self.sites, experiments)
 
         results = output.getvalue().split('\n')
+        # We are using custom functions here because of the size of the results
+        # list. The results list will contain 50+ items. Using the built-in
+        # assertItemsEqual() would require creating a very large, unwieldy
+        # expected_results list. Using the custom functions allows us to not
+        # have to verify the entirety of results, but simply assert that certain
+        # key items are in the results. This is likely sufficient because most
+        # of the items in results are redundant in form.
         self.assertContainsItems(results, expected_results)
         self.assertDoesNotContainsItems(results, unexpected_results)
 

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -144,6 +144,37 @@ class MlabconfigTest(unittest.TestCase):
         results = output.getvalue().split('\n')
         self.assertContainsItems(results, expected_results)
 
+    def test_export_experiment_records_flattened(self):
+        output = StringIO.StringIO()
+        experiments = [model.Slice(name='abc_foo',
+                                   index=1,
+                                   attrs=self.attrs,
+                                   users=self.users,
+                                   use_initscript=True,
+                                   ipv6='all')]
+        expected_results = [
+            mlabconfig.format_a_record('foo-abc-abc01', '192.168.1.11'),
+            mlabconfig.format_a_record('foo-abc-mlab2-abc01', '192.168.1.24'),
+            mlabconfig.format_a_record('foo-abcv4-abc01', '192.168.1.11'),
+            mlabconfig.format_a_record('foo-abc-mlab2v4-abc01', '192.168.1.24'),
+            mlabconfig.format_aaaa_record('foo-abc-abc01',
+                                          '2400:1002:4008::11'),
+            mlabconfig.format_aaaa_record('foo-abc-abc01',
+                                          '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record('foo-abc-mlab3-abc01',
+                                          '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record('foo-abcv6-abc01',
+                                          '2400:1002:4008::11'),
+            mlabconfig.format_aaaa_record('foo-abc-mlab1v6-abc01',
+                                          '2400:1002:4008::11'),
+        ]
+
+        mlabconfig.SSL_EXPERIMENTS = ['abc_foo']
+        mlabconfig.export_experiment_records(output, self.sites, experiments)
+
+        results = output.getvalue().split('\n')
+        self.assertContainsItems(results, expected_results)
+
     @mock.patch.object(mlabconfig, 'get_revision')
     def test_serial_rfc1912(self, mock_get_revision):
         # Fri Oct 31 00:45:00 2015 UTC.

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -31,6 +31,11 @@ class MlabconfigTest(unittest.TestCase):
         for expected in expected_items:
             self.assertIn(expected, results)
 
+    def assertDoesNotContainsItems(self, results, unexpected_items):
+        """Asserts that every element of unexpected is NOT in results."""
+        for unexpected in unexpected_items:
+            self.assertNotIn(unexpected, results)
+
     def test_export_mlab_host_ips(self):
         # Setup synthetic user, site, and experiment configuration data.
         experiments = [model.Slice(name='abc_bar',
@@ -153,19 +158,20 @@ class MlabconfigTest(unittest.TestCase):
                                    use_initscript=True,
                                    ipv6='all')]
         expected_results = [
-            mlabconfig.format_a_record('foo-abc-abc01', '192.168.1.11'),
             mlabconfig.format_a_record('foo-abc-mlab2-abc01', '192.168.1.24'),
-            mlabconfig.format_a_record('foo-abcv4-abc01', '192.168.1.11'),
             mlabconfig.format_a_record('foo-abc-mlab2v4-abc01', '192.168.1.24'),
-            mlabconfig.format_aaaa_record('foo-abc-abc01',
-                                          '2400:1002:4008::11'),
-            mlabconfig.format_aaaa_record('foo-abc-abc01',
-                                          '2400:1002:4008::37'),
             mlabconfig.format_aaaa_record('foo-abc-mlab3-abc01',
                                           '2400:1002:4008::37'),
-            mlabconfig.format_aaaa_record('foo-abcv6-abc01',
-                                          '2400:1002:4008::11'),
             mlabconfig.format_aaaa_record('foo-abc-mlab1v6-abc01',
+                                          '2400:1002:4008::11'),
+        ]
+
+        unexpected_results = [
+            mlabconfig.format_a_record('foo-abc-abc01', '192.168.1.24'),
+            mlabconfig.format_a_record('foo-abcv4-abc01', '192.168.1.24'),
+            mlabconfig.format_aaaa_record('foo-abc-abc01',
+                                          '2400:1002:4008::37'),
+            mlabconfig.format_aaaa_record('foo-abcv6-abc01',
                                           '2400:1002:4008::11'),
         ]
 
@@ -174,6 +180,7 @@ class MlabconfigTest(unittest.TestCase):
 
         results = output.getvalue().split('\n')
         self.assertContainsItems(results, expected_results)
+        self.assertDoesNotContainsItems(results, unexpected_results)
 
     @mock.patch.object(mlabconfig, 'get_revision')
     def test_serial_rfc1912(self, mock_get_revision):


### PR DESCRIPTION
Our NDT SSL certificate works by matching on `*.measurement-lab.org`.  That wildcard match will not work on, say, ndt.iupui.mlab2.den01.measurement-lab.org, because wildcards to not span subdomains.  To get around this we publish names like ndt-iupui-mlab2-den01.measurement-lab.org.  The wildcard matching _will_ match hyphens. This PR adds these "flattened" names.