### PR TITLE
Support evaluating network configuration templates with mlabconfig.py

### DIFF
--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -402,7 +402,7 @@ def export_mlab_server_network_config(output, sites, name_tmpl, input_tmpl,
         output: open file for writing, progress messages are written here.
         sites: list of model.Site, where all sites are processed.
         name_tmpl: str, the name of an output file as a template.
-        input_tmpl: str, the name of a file whose contents are a template.
+        input_tmpl: open file for reading, contains the template content.
         select_regex: str, a regular expression used to select node hostnames.
 
     Raises:

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -119,14 +119,23 @@ def parse_flags():
                       default=ZONE_HEADER_TEMPLATE,
                       help='The full path to zone header file.')
     parser.add_option(
-        '', '--template_input', dest='template', default=None,
+        '',
+        '--template_input',
+        dest='template',
+        default=None,
         help='Template to apply values. Creates a new file for every hostname.')
     parser.add_option(
-        '', '--template_output', dest='filename', default=None,
+        '',
+        '--template_output',
+        dest='filename',
+        default=None,
         help=('Filename interpreted as a template where interpreted template '
               'files are written.'))
     parser.add_option(
-        '', '--select', dest='select', default=None,
+        '',
+        '--select',
+        dest='select',
+        default=None,
         help=('A regular expression used to select a subset of hostnames. If '
               'not specified, all machine names are selected.'))
 
@@ -364,8 +373,8 @@ def export_mlab_host_ips(output, sites, experiments):
 # TODO(soltesz): this function is too specific to node network configuration.
 # Replace this function with a more general interface for accessing
 # configuration information for a site, node, slice, or otherwise.
-def export_mlab_server_network_config(
-    output, sites, name_tmpl, input_tmpl, select_regex):
+def export_mlab_server_network_config(output, sites, name_tmpl, input_tmpl,
+                                      select_regex):
     """Evaluates an input template using variables from every node's interface.
 
     NOTE: Only fields from the model.Node.interface() object are supported.
@@ -380,6 +389,9 @@ def export_mlab_server_network_config(
         name_tmpl: str, the name of an output file as a template.
         input_tmpl: str, the name of a file whose contents are a template.
         select_regex: str, a regular expression used to select node hostnames.
+
+    Raises:
+        IOError, could not create or write to a file.
     """
     tmpl = BracketTemplate(input_tmpl.read())
     output_name = BracketTemplate(name_tmpl)

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -354,7 +354,7 @@ def export_mlab_host_ips(output, sites, experiments):
         # TODO(soltesz): change 'network_list' to a sorted list of node objects.
         for _, node in experiment['network_list']:
             if experiment['index'] is None:
-            continue
+                continue
             output.write(
                 '{name},{ipv4},{ipv6}\n'.format(name=experiment.hostname(node),
                                                 ipv4=experiment.ipv4(node),

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -11,6 +11,36 @@ import time
 import unittest
 
 
+class BracketTemplateTest(unittest.TestCase):
+
+    def setUp(self):
+        self.vars = {'var1': 'Spot', 'var2': 'Dog'}
+
+    def test_substitute_when_template_is_correct(self):
+        tmpl = mlabconfig.BracketTemplate('{{var1}} is a {{var2}}')
+
+        actual = tmpl.safe_substitute(self.vars)
+
+        self.assertEqual(actual, 'Spot is a Dog')
+
+    def test_substitute_when_template_is_broken(self):
+        tmpl = mlabconfig.BracketTemplate('var1}} is a {{var2')
+
+        actual = tmpl.safe_substitute(self.vars)
+
+        self.assertEqual(actual, 'var1}} is a {{var2')
+
+    def test_substitute_when_template_is_shell(self):
+        tmpl1 = mlabconfig.BracketTemplate('$var1 == {{var1}}')
+        tmpl2 = mlabconfig.BracketTemplate('${var2} == {{var2}}')
+
+        actual1 = tmpl1.safe_substitute(self.vars)
+        actual2 = tmpl2.safe_substitute(self.vars)
+
+        self.assertEqual(actual1, '$var1 == Spot')
+        self.assertEqual(actual2, '${var2} == Dog')
+
+
 class MlabconfigTest(unittest.TestCase):
 
     def setUp(self):
@@ -233,6 +263,9 @@ class MlabconfigTest(unittest.TestCase):
         mlabconfig.export_mlab_zone_header(output, header, options)
 
         self.assertEqual(output.getvalue(), 'before; middle; after')
+
+    def test_export_mlab_server_network_config(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -31,7 +31,7 @@ def OpenStringIO(sio):
             self.assertEqual(output.getvalue(), 'Expected content')
 
     Args:
-        sio: StringIO.StringIO, the instance returned returned by 'open'.
+        sio: StringIO.StringIO, the instance returned by 'open'.
     """
     try:
         yield sio

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -17,8 +17,7 @@ import unittest
 def OpenStringIO(sio):
     """Creates a StringIO object that is context aware.
 
-    OpenStringIO is useful for testing functions that opens a file and writes to
-    it.
+    OpenStringIO is useful for testing functions that open and write to a file.
 
     Example:
         @mock.patch('__builtin__.open')
@@ -84,8 +83,8 @@ class MlabconfigTest(unittest.TestCase):
                                      self.users,
                                      nodegroup='MeasurementLabCentos')]
         self.attrs = [model.Attr('MeasurementLabCentos', disk_max='60000000')]
-        # Turn off logging output during testing (unless critical).
-        logging.disable(logging.CRITICAL)
+        # Turn off logging output during testing (unless CRITICAL).
+        logging.disable(logging.ERROR)
 
     def assertContainsItems(self, results, expected_items):
         """Asserts that every element of expected is present in results."""


### PR DESCRIPTION
This PR adds a feature to `mlabconfig.py` for generating per-machine files based on templates using the machine network configuration as variables.

The immediate use case for this feature is to help automate the creation of ROM images for ePoxy. Every ROM embeds a stage1.ipxe script which must include the static network configuration (ip, gateway, dns) and hostname.

For example, this command:
```
mlabconfig.py --format=server-network-config  \
        --template_input=stage1.ipxe.template \
        --template_output="$DIR/stage1-{{hostname}}.ipxe" \
        --select=".*iad1t.*"
```
would generate four ipxe scripts for the servers in IAD0T in the output directory, each with values specific to that server. These files would be input to a ROM generation process as part of ePoxy.