### PR TITLE
Makes SSH config match both short and long node names.

### DIFF
--- a/tools/get-mlab-sshconfig.py
+++ b/tools/get-mlab-sshconfig.py
@@ -215,9 +215,10 @@ def add_config_entry(hostname, username, hosts_file, cfg_file, cfg_blob):
     """ Adds an ssh config entry for an M-Lab host to cfg_file, if not already
         in cfg_blob
     """
-    cfgentry = "Host %s\n  HostName %s\n  Port 806\n  User %s\n"
+    cfgentry = "Host %s %s\n  HostName %s\n  Port 806\n  User %s\n"
     cfgentry+= "  UserKnownHostsFile %s\n"
-    cfgentry = cfgentry % (hostname[:11], hostname, username, hosts_file)
+    cfgentry = cfgentry % (hostname[:11], hostname, hostname, username,
+        hosts_file)
     found = re.search(cfgentry, cfg_blob, re.MULTILINE)
     if not found:
         print "Adding entry for %s to %s" % (hostname, cfg_file)


### PR DESCRIPTION
Makes get-mlab-sshconfig.py generate config blocks that match both the short and long node names.

Instead of blocks looking like

```
Host mlab1.abc01
  Host mlab1.abc01.measurement-lab.org
  Port 806
  [...]
```

... entries will now look like:

```
Host mlab1.abc01 mlab1.abc01.measurement-lab.org
  Host mlab1.abc01.measurement-lab.org
  Port 806
  [...]
```

The main impetus behind this is that scripts for managing the platform should more properly use the FQDN of the node, not convenience names.  This change make it so Ops people can use short names for their convenience, yet scripts can use the FQDN.