### PR TITLE
Change default user from root to site_admin in ssh config file

### DIFF
--- a/tools/get-mlab-sshconfig.py
+++ b/tools/get-mlab-sshconfig.py
@@ -301,7 +301,7 @@ def parse_options():
     parser.set_defaults(knownhosts=False,
                         update=False,
                         config=False,
-                        user="root",
+                        user="site_admin",
                         verbose=False,
                         debug=False)
 


### PR DESCRIPTION
This change causes the get-mlab-sshconfig.py tool to populate the user's ssh config file with the site_admin username instead of root. We overwhelmingly use site_admin; root is only for special cases, most of which have to do with old test servers slated for decommissioning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/79)
<!-- Reviewable:end -->
