### PR TITLE
Adds a new 'automation' user which will have minimum privs

### DIFF
--- a/plsync/users.py
+++ b/plsync/users.py
@@ -10,4 +10,5 @@ user_list = [('Stephen', 'Stuart', 'sstuart@google.com'),
              ('Fernanda', 'Lavalle', 'lavalle@opentechinstitute.org'),
              ('Michael', 'Lynch', 'mtlynch@google.com'),
              ('Greg', 'Russell', 'gfr@google.com'),
-             ('Josh', 'King', 'jking@chambana.net')]
+             ('Josh', 'King', 'jking@chambana.net'),
+             ('M-Lab', 'Automation', 'support@measurementlab.net')]


### PR DESCRIPTION
We now have at least one use case (Rebot) where we have a script getting run by cron that needs access to platform metadata. This job is currently being run from a PI's account, which isn't idea because:

* the job is tied to a specific person, rather than M-Lab generally.
* the person has more privileges than are needed to run this job.

This PR adds a new user which will get the minimum necessary privileges to do what most automated jobs will need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/94)
<!-- Reviewable:end -->
