### PR TITLE
Sets UserKnownHostsFile option to /dev/null in REBOOT.exp

### DIFF
--- a/tools/exp/REBOOT.exp
+++ b/tools/exp/REBOOT.exp
@@ -11,7 +11,8 @@ set prompt "\\$|system>|/.*>|</>hpiLO->"
 
 log_user 1
 if { "$method" == "ssh" } {
-    #send_user "spawn ssh -o StrictHostKeyChecking=no \
+    #send_user "spawn ssh -o UserKnownHostsFile=/dev/null \
+    #                     -o StrictHostKeyChecking=no \
     #                     -o PasswordAuthentication=yes \
     #                     -o PubkeyAuthentication=no $user@$host\n"
     set cont 0
@@ -21,11 +22,13 @@ if { "$method" == "ssh" } {
         #       stderr redirected to stdout, others only work without it.
         if { $retry == 0 } {
             spawn ssh -o Port=806 \
+                      -o UserKnownHostsFile=/dev/null \
                       -o StrictHostKeyChecking=no \
                       -o PasswordAuthentication=yes \
                       -o PubkeyAuthentication=no $user@$host 
         } else {
             spawn ssh -o Port=806 \
+                      -o UserKnownHostsFile=/dev/null \
                       -o StrictHostKeyChecking=no \
                       -o PasswordAuthentication=yes \
                       -o PubkeyAuthentication=no $user@$host 2>&1


### PR DESCRIPTION
Rebot currently uses drac.py to reboot nodes that have hung. The `expect` script turns off `StrictHostKeyChecking`, but this still stores the hosts key in ~/.ssh/known_hosts. For some reason, SSH host keys occasionally change on DRACs. When this happens, Rebot is unable to reboot the down node, since SSH throws a warning that the host key changed. Since Rebot is an unattended, automated tool, a node may stay down for quite a long time before an operator notices, and then has to manually reboot the node and/or login to EB to fix `known_hosts`.

This PR sets the option `UserKnownHostsFile` to `/dev/null`, which should workaround DRACs whose host keys have changed for any reason.