### PR TITLE
Generate blackbox targets for snmp_exporter service for all sites.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -7,7 +7,7 @@ BASEDIR=${PWD}
 
 # Create all output directories.
 for project in mlab-sandbox mlab-staging mlab-oti ; do
-  mkdir -p ${BASEDIR}/gen/${project}/prometheus/{legacy-targets,blackbox-targets}
+  mkdir -p ${BASEDIR}/gen/${project}/prometheus/{legacy-targets,blackbox-targets,snmp-targets}
 done
 
 # All testing sites and machines.
@@ -46,7 +46,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
         --label service=snmp_exporter > \
-        ${output}/blackbox-targets/snmpexporter.json
+        ${output}/snmp-targets/snmpexporter.json
 
     # Sidestream exporter in the npad experiment.
     ./mlabconfig.py --format=prom-targets \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -42,6 +42,13 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --label module=ssh_v4_online \
         --select="${!pattern}" > ${output}/blackbox-targets/ssh806.json
 
+    # snmp_exporter on port 9116
+    ./mlabconfig.py --format=prom-targets-sites \
+        --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
+        --label service=snmpexporter \
+        --label module=switch_snmp_metrics > \
+        ${output}/blackbox-targets/snmpexporter.json
+
     # Sidestream exporter in the npad experiment.
     ./mlabconfig.py --format=prom-targets \
         --template_target={{hostname}}:9090 \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -45,8 +45,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
     # snmp_exporter on port 9116
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
-        --label service=snmpexporter \
-        --label module=switch_snmp_metrics > \
+        --label service=snmp_exporter > \
         ${output}/blackbox-targets/snmpexporter.json
 
     # Sidestream exporter in the npad experiment.

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -130,6 +130,10 @@ EXAMPLES:
         --label module=ssh_v4_online \
         --label service=machine_online \
         --select=".*lga0t.*"
+
+    mlabconfig.py --format=prom-targets-sites \
+        --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
+        --label service=snmp_exporter
 """
 
 
@@ -686,6 +690,37 @@ def select_prometheus_node_targets(sites, select_regex, target_template,
     return records
 
 
+def select_prometheus_site_targets(sites, select_regex, target_template,
+                                  common_labels):
+    """Selects and formats site targets.
+
+    Args:
+      sites: list of planetlab.Site objects, used to generate site names.
+      select_regex: str, a regex used to choose a subset of hostnames. Ignored
+          if empty.
+      target_template: str, a template for formatting the target from the
+          hostname. e.g. s1.{{sitename}}.measurement-lab.org:9116
+      common_labels: dict of str, a set of labels to apply to all targets.
+
+    Returns:
+      list of dict, each element is a dict with 'labels' (a dict of key/values)
+          and 'targets' (a list of targets).
+    """
+    records = []
+    target_tmpl = BracketTemplate(target_template)
+    for site in sites:
+        if select_regex and not re.search(select_regex, site['name']):
+            continue
+        labels = common_labels.copy()
+        labels['module'] = site['name']
+        target = target_tmpl.safe_substitute({'sitename': site['name']})
+        records.append({
+            'labels': labels,
+            'targets': [target],
+        })
+    return records
+
+
 def main():
     (options, args) = parse_flags()
 
@@ -734,6 +769,12 @@ def main():
     elif options.format == 'prom-targets-nodes':
         # TODO(soltesz): support v4 only or v6 only options.
         records = select_prometheus_node_targets(
+            sites, options.select, options.template_target, options.labels)
+        json.dump(records, sys.stdout, indent=4)
+
+    elif options.format == 'prom-targets-sites':
+        # TODO(soltesz): support v4 only or v6 only options.
+        records = select_prometheus_site_targets(
             sites, options.select, options.template_target, options.labels)
         json.dump(records, sys.stdout, indent=4)
 

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -712,7 +712,7 @@ def select_prometheus_site_targets(sites, select_regex, target_template,
         if select_regex and not re.search(select_regex, site['name']):
             continue
         labels = common_labels.copy()
-        labels['module'] = site['name']
+        labels['site'] = site['name']
         target = target_tmpl.safe_substitute({'sitename': site['name']})
         records.append({
             'labels': labels,

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -588,7 +588,7 @@ class MlabconfigTest(unittest.TestCase):
         expected_targets = [
             {
                 'labels': {
-                    'module': 'abc01'
+                    'site': 'abc01'
                 },
                 'targets': [
                     's1.abc01.measurement-lab.org:9116'

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -584,6 +584,24 @@ class MlabconfigTest(unittest.TestCase):
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(actual_targets, expected_targets)
 
+    def test_select_prometheus_site_targets(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'module': 'abc01'
+                },
+                'targets': [
+                    's1.abc01.measurement-lab.org:9116'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_site_targets(
+            self.sites, None, 's1.{{sitename}}.measurement-lab.org:9116', {})
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(actual_targets, expected_targets)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Then Prometheus snmp_exporter service is currently deployed in a GCE instance in the mlab-sandbox project. It will later also be deployed to mlab-staging and mlab-oti. This PR updates mlabconfig.py to generate Prometheus blackbox target configurations for the snmp_exporter service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/152)
<!-- Reviewable:end -->
