### PR TITLE
Adds an __exporter-project label to the site-targets generator

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -44,7 +44,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
 
     # snmp_exporter on port 9116
     ./mlabconfig.py --format=prom-targets-sites \
-        --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
+        --template_target=s1.{{sitename}}.measurement-lab.org \
         --label service=snmp \
         --label __exporter_project=${project#mlab-} > \
         ${output}/snmp-targets/snmpexporter.json

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -45,7 +45,8 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
     # snmp_exporter on port 9116
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
-        --label service=snmp_exporter > \
+        --label service=snmp \
+        --label __exporter-project=${project#mlab-} > \
         ${output}/snmp-targets/snmpexporter.json
 
     # Sidestream exporter in the npad experiment.

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -46,7 +46,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
         --label service=snmp \
-        --label __exporter-project=${project#mlab-} > \
+        --label __exporter_project=${project#mlab-} > \
         ${output}/snmp-targets/snmpexporter.json
 
     # Sidestream exporter in the npad experiment.

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -132,7 +132,7 @@ EXAMPLES:
         --select=".*lga0t.*"
 
     mlabconfig.py --format=prom-targets-sites \
-        --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
+        --template_target=s1.{{sitename}}.measurement-lab.org \
         --label service=snmp \
         --label __exporter-project=sandbox
 """

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -133,7 +133,8 @@ EXAMPLES:
 
     mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org:9116 \
-        --label service=snmp_exporter
+        --label service=snmp \
+        --label __exporter-project=sandbox
 """
 
 

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -134,7 +134,7 @@ EXAMPLES:
     mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org \
         --label service=snmp \
-        --label __exporter-project=sandbox
+        --label __exporter_project=sandbox
 """
 
 


### PR DESCRIPTION
The value of this label can/will be rewritten later into an address suitable for a given GCP project. [In the case of snmp_exporter will ultimately be rewritten](https://github.com/m-lab/prometheus-support/pull/86/files#diff-a6295754801545c8cb25f37e0860300aR411) to something like "snmp-exporter.sandbox.measurementlab.net:9116".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/155)
<!-- Reviewable:end -->
