### PR TITLE
Updates canary machine list to include a few more and a better diversity.

### DIFF
--- a/plsync/canary_machines.txt
+++ b/plsync/canary_machines.txt
@@ -1,6 +1,10 @@
-mlab1.atl06.measurement-lab.org
-mlab1.dfw01.measurement-lab.org
-mlab1.ham01.measurement-lab.org
-mlab1.lhr01.measurement-lab.org
-mlab1.nuq02.measurement-lab.org
+mlab1.bru01.measurement-lab.org
+mlab1.fra01.measurement-lab.org
+mlab1.lax04.measurement-lab.org
+mlab1.lga03.measurement-lab.org
+mlab1.lhr05.measurement-lab.org
+mlab1.mia02.measurement-lab.org
+mlab1.nuq05.measurement-lab.org
+mlab1.ord04.measurement-lab.org
+mlab1.sea06.measurement-lab.org
 mlab1.wlg02.measurement-lab.org

--- a/plsync/canary_machines.txt
+++ b/plsync/canary_machines.txt
@@ -1,6 +1,6 @@
 mlab1.bru01.measurement-lab.org
 mlab1.fra01.measurement-lab.org
-mlab1.lax04.measurement-lab.org
+mlab1.lax01.measurement-lab.org
 mlab1.lga03.measurement-lab.org
 mlab1.lhr05.measurement-lab.org
 mlab1.mia02.measurement-lab.org


### PR DESCRIPTION
The new list includes 10 machines, with an attempt to get a diversity of transit providers in a diversity of locations:

```
mlab1.bru01.measurement-lab.org, Vodafone, 10Gbps, Upgraded
mlab1.fra01.measurement-lab.org, Telia, 10Gbps, Upgraded
mlab1.lax01.measurement-lab.org, Cogent, 1Gbps, Legacy
mlab1.lga03.measurement-lab.org, Tata, 1Gbps, Upgraded
mlab1.lhr05.measurement-lab.org, Level3, 1Gbps, Upgraded
mlab1.mia02.measurement-lab.org, Cogent, 1Gbps, Upgraded
mlab1.nuq05.measurement-lab.org, XO, 1Gbps, Upgraded
mlab1.ord04.measurement-lab.org, GTT, 1Gbps, Upgraded
mlab1.sea06.measurement-lab.org, Internap, 1Gbps, Upgraded
mlab1.wlg02.measurement-lab.org, Victoria University, 1Gbps, Legacy
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/161)
<!-- Reviewable:end -->
