### PR TITLE
Generates more blackbox_exporter targets, multiple --target_template, bugfix

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -42,21 +42,21 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --label module=ssh_v4_online \
         --select="${!pattern}" > ${output}/blackbox-targets/ssh806.json
 
-    # NDT on port 3001.
+    # NDT "raw" on port 3001.
     ./mlabconfig.py --format=prom-targets \
         --template_target={{hostname}}:3001 \
-        --label service=ndt3001 \
+        --label service=ndt_raw \
         --label module=tcp_v4_online \
         --select="ndt.iupui.(${!pattern})" > \
-            ${output}/blackbox-targets/ndt3001.json
+            ${output}/blackbox-targets/ndt_raw.json
 
     # NDT SSL on port 3010.
     ./mlabconfig.py --format=prom-targets \
         --template_target={{hostname}}:3010 \
-        --label service=ndt3010 \
+        --label service=ndt_ssl \
         --label module=tcp_v4_tls_online \
         --select="ndt.iupui.(${!pattern})" > \
-            ${output}/blackbox-targets/ndt3010.json
+            ${output}/blackbox-targets/ndt_ssl.json
 
     # Mobiperf on ports 6001, 6002, 6003.
     ./mlabconfig.py --format=prom-targets \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -58,6 +58,16 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --select="ndt.iupui.(${!pattern})" > \
             ${output}/blackbox-targets/ndt3010.json
 
+    # Mobiperf on ports 6001, 6002, 6003.
+    ./mlabconfig.py --format=prom-targets \
+        --template_target={{hostname}}:6001 \
+        --template_target={{hostname}}:6002 \
+        --template_target={{hostname}}:6003 \
+        --label service=mobiperf \
+        --label module=tcp_v4_online \
+        --select="1.michigan.(${!pattern})" > \
+            ${output}/blackbox-targets/mobiperf.json
+
     # snmp_exporter on port 9116.
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -68,6 +68,14 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --select="1.michigan.(${!pattern})" > \
             ${output}/blackbox-targets/mobiperf.json
 
+    # neubot on port 9773.
+    ./mlabconfig.py --format=prom-targets \
+        --template_target={{hostname}}:9773/sapi/state \
+        --label service=neubot \
+        --label module=neubot_online \
+        --select="neubot.mlab.(${!pattern})" > \
+            ${output}/blackbox-targets/neubot.json
+
     # snmp_exporter on port 9116.
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -42,6 +42,22 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --label module=ssh_v4_online \
         --select="${!pattern}" > ${output}/blackbox-targets/ssh806.json
 
+    # NDT on port 3001.
+    ./mlabconfig.py --format=prom-targets \
+        --template_target={{hostname}}:3001 \
+        --label service=ndt3001 \
+        --label module=tcp_v4_online \
+        --select="ndt.iupui.(${!pattern})" > \
+            ${output}/blackbox-targets/ndt3001.json
+
+    # NDT SSL on port 3010.
+    ./mlabconfig.py --format=prom-targets \
+        --template_target={{hostname}}:3010 \
+        --label service=ndt3010 \
+        --label module=tcp_v4_tls_online \
+        --select="ndt.iupui.(${!pattern})" > \
+            ${output}/blackbox-targets/ndt3010.json
+
     # snmp_exporter on port 9116.
     ./mlabconfig.py --format=prom-targets-sites \
         --template_target=s1.{{sitename}}.measurement-lab.org \

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -224,7 +224,7 @@ def parse_flags():
         '--rsync',
         dest='rsync',
         action='store_true',
-        default=True,
+        default=False,
         help='Only process experiments that have rsync modules defined.')
     parser.add_option(
         '',

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -209,7 +209,8 @@ def parse_flags():
         '',
         '--template_target',
         dest='template_target',
-        default='{{hostname}}:7999',
+        action='append',
+        default=[],
         help=('Target is interpreted as a template used to format blackbox '
               'targets.'))
     parser.add_option(
@@ -643,14 +644,14 @@ def export_scraper_kubernetes_config(filename_template, experiments,
 
 
 def select_prometheus_experiment_targets(
-    experiments, select_regex, target_template, common_labels, rsync_only):
+    experiments, select_regex, target_templates, common_labels, rsync_only):
     """Selects and formats targets from experiments.
 
     Args:
       experiments: list of planetlab.Slice objects, used to enumerate hostnames.
       select_regex: str, a regex used to choose a subset of hostnames. Ignored
           if empty.
-      target_template: str, a template for formatting the target from the
+      target_templates: list of templates for formatting the target(s) from the
           hostname. e.g. {{hostname}}:7999, https://{{hostname}}/some/path
       common_labels: dict of str, a set of labels to apply to all targets.
       rsync_only: bool, skip experiments without rsync_modules.
@@ -660,7 +661,6 @@ def select_prometheus_experiment_targets(
           and 'targets' (a list of targets).
     """
     records = []
-    target_tmpl = BracketTemplate(target_template)
     for experiment in experiments:
         for _, node in experiment['network_list']:
             # Skip experiments without an IP index.
@@ -676,15 +676,19 @@ def select_prometheus_experiment_targets(
             if not rsync_only or experiment['rsync_modules']:
                 if select_regex and not re.search(select_regex, host):
                     continue
-                target = target_tmpl.safe_substitute({'hostname': host})
+                targets = []
+                for tmpl in target_templates:
+                    target_tmpl = BracketTemplate(tmpl)
+                    target = target_tmpl.safe_substitute({'hostname': host})
+                    targets.append(target)
                 records.append({
                     'labels': labels,
-                    'targets': [target],
+                    'targets': targets,
                 })
     return records
 
 
-def select_prometheus_node_targets(sites, select_regex, target_template,
+def select_prometheus_node_targets(sites, select_regex, target_templates,
                                    common_labels):
     """Selects and formats targets from site nodes.
 
@@ -692,7 +696,7 @@ def select_prometheus_node_targets(sites, select_regex, target_template,
       sites: list of planetlab.Site objects, used to generate hostnames.
       select_regex: str, a regex used to choose a subset of hostnames. Ignored
           if empty.
-      target_template: str, a template for formatting the target from the
+      target_templates: list of templates for formatting the target(s) from the
           hostname. e.g. {{hostname}}:7999, https://{{hostname}}/some/path
       common_labels: dict of str, a set of labels to apply to all targets.
 
@@ -701,22 +705,25 @@ def select_prometheus_node_targets(sites, select_regex, target_template,
           and 'targets' (a list of targets).
     """
     records = []
-    target_tmpl = BracketTemplate(target_template)
     for site in sites:
         for _, node in site['nodes'].iteritems():
             if select_regex and not re.search(select_regex, node.hostname()):
                 continue
             labels = common_labels.copy()
             labels['machine'] = node.hostname()
-            target = target_tmpl.safe_substitute({'hostname': node.hostname()})
+            targets = []
+            for tmpl in target_templates:
+                target_tmpl = BracketTemplate(tmpl)
+                target = target_tmpl.safe_substitute({'hostname': node.hostname()})
+                targets.append(target)
             records.append({
                 'labels': labels,
-                'targets': [target],
+                'targets': targets,
             })
     return records
 
 
-def select_prometheus_site_targets(sites, select_regex, target_template,
+def select_prometheus_site_targets(sites, select_regex, target_templates,
                                   common_labels):
     """Selects and formats site targets.
 
@@ -724,7 +731,7 @@ def select_prometheus_site_targets(sites, select_regex, target_template,
       sites: list of planetlab.Site objects, used to generate site names.
       select_regex: str, a regex used to choose a subset of hostnames. Ignored
           if empty.
-      target_template: str, a template for formatting the target from the
+      target_templates: list of templates for formatting the target(s) from the
           hostname. e.g. s1.{{sitename}}.measurement-lab.org:9116
       common_labels: dict of str, a set of labels to apply to all targets.
 
@@ -733,16 +740,19 @@ def select_prometheus_site_targets(sites, select_regex, target_template,
           and 'targets' (a list of targets).
     """
     records = []
-    target_tmpl = BracketTemplate(target_template)
     for site in sites:
         if select_regex and not re.search(select_regex, site['name']):
             continue
         labels = common_labels.copy()
         labels['site'] = site['name']
-        target = target_tmpl.safe_substitute({'sitename': site['name']})
+        targets = []
+        for tmpl in target_templates:
+            target_tmpl = BracketTemplate(tmpl)
+            target = target_tmpl.safe_substitute({'sitename': site['name']})
+            targets.append(target)
         records.append({
             'labels': labels,
-            'targets': [target],
+            'targets': targets,
         })
     return records
 

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -531,7 +531,7 @@ class MlabconfigTest(unittest.TestCase):
         ]
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            experiments, None, '{{hostname}}:9090', {}, False)
+            experiments, None, ['{{hostname}}:9090'], {}, False)
 
         self.assertEqual(len(actual_targets), 3)
         self.assertItemsEqual(expected_targets, actual_targets)
@@ -561,7 +561,7 @@ class MlabconfigTest(unittest.TestCase):
         ]
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            experiments, "bar.abc.mlab2.*", '{{hostname}}:9090', {}, False)
+            experiments, "bar.abc.mlab2.*", ['{{hostname}}:9090'], {}, False)
 
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(expected_targets, actual_targets)
@@ -579,10 +579,31 @@ class MlabconfigTest(unittest.TestCase):
         ]
 
         actual_targets = mlabconfig.select_prometheus_node_targets(
-            self.sites, "mlab2.*", '{{hostname}}:9090', {})
+            self.sites, "mlab2.*", ['{{hostname}}:9090'], {})
 
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(actual_targets, expected_targets)
+
+    def test_select_prometheus_node_mulitple_targets(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab2.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'mlab2.abc01.measurement-lab.org:9090',
+                    'mlab2.abc01.measurement-lab.org:8080'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            self.sites, "mlab2.*", ['{{hostname}}:9090', '{{hostname}}:8080'],
+            {})
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(actual_targets, expected_targets)
+
 
     def test_select_prometheus_site_targets(self):
         expected_targets = [
@@ -597,7 +618,7 @@ class MlabconfigTest(unittest.TestCase):
         ]
 
         actual_targets = mlabconfig.select_prometheus_site_targets(
-            self.sites, None, 's1.{{sitename}}.measurement-lab.org:9116', {})
+            self.sites, None, ['s1.{{sitename}}.measurement-lab.org:9116'], {})
 
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(actual_targets, expected_targets)


### PR DESCRIPTION
This PR initially aimed to do one thing: add several new blocks to `generate_prometheus_targets.sh` to generate blackbox_exporter target files for various services which mlab-ns relies on for state. However, a couple other things got in the way, so now this PR includes:

* The original stated goal above, generating targets for NDT on port 3001, NDT SSL on port 3010, mobiperf, and neubot.

* The existing mobiperf Nagios check inspects for connectivity on 3 ports: 6001, 6002, and 6003. The existing templating system would have required me to generate 3 separate sets of configs, one for each port. However, each scrape config block can accept multiple `targets`. I made some changes to `mlabconfig.py` so that it now can accept multiple `--target_template` options, which will result in multiple entries in the `targets` section of each scrape block.

* There was a small bug in the `--rsync` option whereby it was impossible to actually turn the flag off... whether you included the flag in your call or not, it was present in options with a value of `True`. The fix was to set the default value to `False`. In this way, if the flag is present `rsync` will be `True`, else it will be false (or just not even existent, actually).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/163)
<!-- Reviewable:end -->
