### PR TITLE
Updates the IPv4 prefix for AMS06 (LeaseWeb). 

### DIFF
--- a/plsync/sites.py
+++ b/plsync/sites.py
@@ -68,7 +68,7 @@ site_list = [
     makesite('ams03','80.239.169.0',   '2001:2030:32::',       'Amsterdam', 'NL', 52.308600, 4.763890, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('ams04','77.67.114.64',   '2001:668:1f:5f::',     'Amsterdam', 'NL', 52.308600, 4.763890, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('ams05','195.89.145.0',   '2001:5002:100:21::',   'Amsterdam', 'NL', 52.308600, 4.763890, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
-    makesite('ams06','81.17.34.0',     '2001:1af8:4900:b070::','Amsterdam', 'NL', 52.308600, 4.763890, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
+    makesite('ams06','212.32.246.192', '2001:1af8:4900:b070::','Amsterdam', 'NL', 52.308600, 4.763890, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('arn02','195.89.146.192', '2001:5012:100:24::',   'Stockholm', 'SE', 59.651900, 17.918600, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('arn03','213.242.86.64',  '2001:4c08:2003:44::',  'Stockholm', 'SE', 59.651900, 17.918600, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('arn04','62.115.225.128', '2001:2030:0:38::',     'Stockholm', 'SE', 59.651900, 17.918600, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),


### PR DESCRIPTION
They apparently realized the block they gave us was one they needed:

> We had to change the IP addresses because we assigned a range that
is in use by a very important part of our infrastructure. We are
sorry for the inconvenience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/166)
<!-- Reviewable:end -->
