### PR TITLE
Allows whitelisting of entire sites for a slice for IPv6.

### DIFF
--- a/plsync/planetlab/model.py
+++ b/plsync/planetlab/model.py
@@ -532,8 +532,8 @@ class Slice(dict):
                     nodes on which plsync is called explicitly.
         ipv6 - how to enable IPv6 for this slice. Options are:
                 "all" - add IPv6 addres to all nodes
-                [] - a list of abbreviated hostnames, i..e ['mlab1.nuq01', 
-                    'mlab2.nuq02', ...]
+                [] - a list of abbreviated hostnames and/or sites, i.e.,
+                     ['mlab1.nuq01', 'sea03', 'mia01', 'mlab3.den04', ...]
                 None - do not enble IPv6 addressing anywhere.
     """
 
@@ -561,8 +561,21 @@ class Slice(dict):
             if type(kwargs['ipv6']) == str:
                 kwargs['ipv6'] = "all"
             elif type(kwargs['ipv6']) == type([]):
-                kwargs['ipv6'] = ['%s.%s' % (host, MLAB_ORG_DOMAIN)
-                                  for host in kwargs['ipv6']]
+                ipv6_hosts = []
+                for host in kwargs['ipv6']:
+                    # This is a node (e.g., mlab1.sea02)
+                    if len(host.split('.')) == 2:
+                        ipv6_hosts.append('%s.%s' % (host, MLAB_ORG_DOMAIN))
+                    # This is a site (e.g., sea02)
+                    elif len(host.split('.')) == 1:
+                        for node in ['mlab1', 'mlab2', 'mlab3', 'mlab4']:
+                            ipv6_hosts.append('%s.%s.%s' % (node, host,
+                                              MLAB_ORG_DOMAIN))
+                    # We don't know what this is. Raise an error.
+                    else:
+                        raise Exception("Unrecognized node/site for ipv6"+
+                                        "parameter: %s" % host)
+                kwargs['ipv6'] = ipv6_hosts
             else:
                 raise Exception("Unrecognized type for ipv6 parameter: %s" % 
                                     type(kwargs['ipv6']))

--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -79,7 +79,10 @@ mlab4s_only = ['mlab4.nuq01', 'mlab4.nuq02', 'mlab4.prg01',
 #                  arbitrary initscripts and support resetting.
 # ipv6  : specifies how to assign ipv6 addresses to slices. Accepted values are:
 #            None - do not assign.
-#            list - An explicit list of machine names to permit ipv6 addresses
+#            list - An explicit list of machine and/or site names to permit ipv6
+#                   addresses e.g., ['den01', 'mlab3.bru02', 'mlab1.hnd01']. If
+#                   a bare site name is provided, then every node at the site
+#                   will get an IPv6 address.
 #            "all" - assign ipv6 addresses to all machines
 #         If a site lacks IPv6 addresses, none will be assigned even if "all" is
 #         given. For example, see lca01+npad.


### PR DESCRIPTION
Currently, in the file `slices.py` there are only three options for enabling IPv6 for nodes in a slice:

* every node gets an IPv6 address
* no node gets an IPv6 address
* a list of nodes get IPv6 address

We are preparing to roll out IPv6 at 15 or 20 entire sites. To avoid having to manually enter 70 or 80 short node names this PR implements a change that allows the user to enter a bare site name in the whitelist. If encountered, the `Slice()` model will automatically expand that to all nodes at a site.  By default, this is done for `['mlab1', 'mlab2', 'mlab3', 'mlab3']`. Not every site currently has 4 nodes, but apparently this doesn't raise any exceptions on `--syncslice` for a 3-node site, at least when running `./plsync.py --dryrun`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/168)
<!-- Reviewable:end -->
