### PR TITLE
Adds a --flatnames option to mlabconfig.py

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -55,7 +55,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --template_target={{hostname}}:3010 \
         --label service=ndt_ssl \
         --label module=tcp_v4_tls_online \
-        --flatnames \
+        --use_flatnames \
         --select="ndt.iupui.(${!pattern})" > \
             ${output}/blackbox-targets/ndt_ssl.json
 

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -55,6 +55,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
         --template_target={{hostname}}:3010 \
         --label service=ndt_ssl \
         --label module=tcp_v4_tls_online \
+        --flatnames \
         --select="ndt.iupui.(${!pattern})" > \
             ${output}/blackbox-targets/ndt_ssl.json
 

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -229,6 +229,13 @@ def parse_flags():
         help='Only process experiments that have rsync modules defined.')
     parser.add_option(
         '',
+        '--flatnames',
+        dest='flatnames',
+        action='store_true',
+        default=False,
+        help='Whether to return TLS-formatted host names (dashes, not dots.)')
+    parser.add_option(
+        '',
         '--select',
         dest='select',
         default=None,
@@ -643,8 +650,9 @@ def export_scraper_kubernetes_config(filename_template, experiments,
                     config_file.write(contents_tmpl.safe_substitute(config))
 
 
-def select_prometheus_experiment_targets(
-    experiments, select_regex, target_templates, common_labels, rsync_only):
+def select_prometheus_experiment_targets(experiments, select_regex,
+                                         target_templates, common_labels,
+                                         rsync_only, flatnames):
     """Selects and formats targets from experiments.
 
     Args:
@@ -655,6 +663,8 @@ def select_prometheus_experiment_targets(
           hostname. e.g. {{hostname}}:7999, https://{{hostname}}/some/path
       common_labels: dict of str, a set of labels to apply to all targets.
       rsync_only: bool, skip experiments without rsync_modules.
+      flatnames: bool, return "flattened" hostnames suitable for TLS/SSL
+          wildcard certificates.
 
     Returns:
       list of dict, each element is a dict with 'labels' (a dict of key/values)
@@ -672,6 +682,11 @@ def select_prometheus_experiment_targets(
             labels['machine'] = node.hostname()
 
             host = experiment.hostname(node)
+            # Don't use the flatten_hostname() function in this module because
+            # it adds too much overhead. Just replace the first three dots with
+            # dashes.
+            if flatnames:
+                host = host.replace('.', '-', 3)
             # Consider all experiments or only those with rsync modules.
             if not rsync_only or experiment['rsync_modules']:
                 if select_regex and not re.search(select_regex, host):
@@ -799,7 +814,7 @@ def main():
         # TODO(soltesz): support v4 only or v6 only options.
         records = select_prometheus_experiment_targets(
             experiments, options.select, options.template_target,
-            options.labels, options.rsync)
+            options.labels, options.rsync, options.flatnames)
         json.dump(records, sys.stdout, indent=4)
 
     elif options.format == 'prom-targets-nodes':

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -229,8 +229,8 @@ def parse_flags():
         help='Only process experiments that have rsync modules defined.')
     parser.add_option(
         '',
-        '--flatnames',
-        dest='flatnames',
+        '--use_flatnames',
+        dest='use_flatnames',
         action='store_true',
         default=False,
         help='Whether to return TLS-formatted host names (dashes, not dots.)')
@@ -652,7 +652,7 @@ def export_scraper_kubernetes_config(filename_template, experiments,
 
 def select_prometheus_experiment_targets(experiments, select_regex,
                                          target_templates, common_labels,
-                                         rsync_only, flatnames):
+                                         rsync_only, use_flatnames):
     """Selects and formats targets from experiments.
 
     Args:
@@ -663,7 +663,7 @@ def select_prometheus_experiment_targets(experiments, select_regex,
           hostname. e.g. {{hostname}}:7999, https://{{hostname}}/some/path
       common_labels: dict of str, a set of labels to apply to all targets.
       rsync_only: bool, skip experiments without rsync_modules.
-      flatnames: bool, return "flattened" hostnames suitable for TLS/SSL
+      use_flatnames: bool, return "flattened" hostnames suitable for TLS/SSL
           wildcard certificates.
 
     Returns:
@@ -685,7 +685,7 @@ def select_prometheus_experiment_targets(experiments, select_regex,
             # Don't use the flatten_hostname() function in this module because
             # it adds too much overhead. Just replace the first three dots with
             # dashes.
-            if flatnames:
+            if use_flatnames:
                 host = host.replace('.', '-', 3)
             # Consider all experiments or only those with rsync modules.
             if not rsync_only or experiment['rsync_modules']:
@@ -814,7 +814,7 @@ def main():
         # TODO(soltesz): support v4 only or v6 only options.
         records = select_prometheus_experiment_targets(
             experiments, options.select, options.template_target,
-            options.labels, options.rsync, options.flatnames)
+            options.labels, options.rsync, options.use_flatnames)
         json.dump(records, sys.stdout, indent=4)
 
     elif options.format == 'prom-targets-nodes':


### PR DESCRIPTION
Currently, the ndt_ssl blackbox_exporter checks are failing. One reason is that the target hostnames are not using the "flattened" domain which is compatible with our wildcard SSL certificate for measurement-lab.org.  This PR adds a `--flatnames` options to mlabconfig.py which can instruct Prom ta0rget generator functions to return flattened domain names suitable for TLS/SSL wildcard certs.

One small change in `generate_prometheus_targets.sh` takes advantage of this new functionality to fix the targets for the `tcp_v4_tls_online` module for  the NDT SSL check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/171)
<!-- Reviewable:end -->
