### PR TITLE
Adds a missing comma to the list of iupui_ndt nodes/sites.

### DIFF
--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -95,7 +95,7 @@ slice_list = [
                                            use_initscript=True,
                                            ipv6=['mlab1.lax01', 'mlab1.mia03', 'mlab1.ham01', 'mlab1.hnd01',
                                                  'ams02', 'arn03', 'atl02', 'bru03', 'den01', 'dfw01', 'fra03',
-                                                 'iad05', 'iad0t', 'iad1t' 'lax02', 'lga07', 'lhr03', 'mia01',
+                                                 'iad05', 'iad0t', 'iad1t', 'lax02', 'lga07', 'lhr03', 'mia01',
                                                  'mil02', 'nuq04', 'par04', 'prg05', 'ord05', 'sea05',],
                                            rsync_modules=['ndt']),
     Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+web100_enable_attr+[


### PR DESCRIPTION
Fixes a syntax error that was causing iad1t and lax01 to be excluded from inclusion in IPv6 testing for iupui_ndt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/175)
<!-- Reviewable:end -->
