### PR TITLE
Generate the inotify targets for all machines

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -72,13 +72,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select="ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt_ssl.json
 
-      # inotify_exporter for NDT on port 9393.
-      ./mlabconfig.py --format=prom-targets \
-          --template_target={{hostname}}:9393 \
-          --label service=inotify \
-          --select="ndt.iupui.(${!pattern})" > \
-              ${output}/legacy-targets/ndt_inotify.json
-
       # Mobiperf on ports 6001, 6002, 6003.
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:6001 \
@@ -97,12 +90,25 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select="neubot.mlab.(${!pattern})" > \
               ${output}/blackbox-targets/neubot.json
 
+      ########################################################################
+      # Note: The following configs select all servers. This allows us to
+      # experiment with monitoring many sites in sandbox or staging before
+      # production.
+      ########################################################################
+
       # snmp_exporter on port 9116.
       ./mlabconfig.py --format=prom-targets-sites \
           --template_target=s1.{{sitename}}.measurement-lab.org \
           --label service=snmp \
           --label __exporter_project=${project#mlab-} > \
               ${output}/snmp-targets/snmpexporter.json
+
+      # inotify_exporter for NDT on port 9393.
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}}:9393 \
+          --label service=inotify \
+          --select="ndt.iupui.*" > \
+              ${output}/legacy-targets/ndt_inotify.json
 
       # node_exporter on port 9100.
       ./mlabconfig.py --format=prom-targets-nodes \


### PR DESCRIPTION
This change enables collecting inotify exporter targets from all machines by non-production instances of prometheus.

This is helpful to support broader testing of new monitoring approaches, such as recording rules for NDT Early Warning and alerts based on them before reaching production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/177)
<!-- Reviewable:end -->
