### PR TITLE
Fixes the snmp_exporter __exporter_project labels.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -100,7 +100,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       ./mlabconfig.py --format=prom-targets-sites \
           --template_target=s1.{{sitename}}.measurement-lab.org \
           --label service=snmp \
-          --label __exporter_project=${project#mlab-} > \
+          --label __exporter_project=${project} > \
               ${output}/snmp-targets/snmpexporter.json
 
       # inotify_exporter for NDT on port 9393.


### PR DESCRIPTION
The old Prom `__address__` relabeling was using the shortened GCP project name, which was generating target addresses of the form `snmp-exporter.oti.measurementlab.net:9116`. However, [short project name domains were deleted in a PR yesterday](https://github.com/m-lab/dns-zones/pull/29). This PR fixes the `__exporter_target` label to contain the full GCP project name such that targets are of the form `snmp-exporter.mlab-oti.measurementlab.net:9116`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/179)
<!-- Reviewable:end -->
