### PR TITLE
Removes lame_duck label from node_exporter targets.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -114,8 +114,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       ./mlabconfig.py --format=prom-targets-nodes \
           --template_target={{hostname}}:9100 \
           --label service=nodeexporter \
-          --label module=lame_duck > \
-              ${output}/legacy-targets/lameduck.json
+              ${output}/legacy-targets/nodeexporter.json
 
     else
       echo "Unknown group name: ${GROUP} for ${project}"


### PR DESCRIPTION
In the early days of node_exporter, it was only used for reading in lame-duck status, and having a "lame_duck" labeled added to the targets made a *little* sense. However, we now use node_exporter several other things, and now the "lame_duck" label makes no sense. This PR removes that label, and additional outputs the node_exporter targets to a file named *nodeexporter.json* (instead of *lameduck.json*)

This PR depends on [another PR in the prometheus-support repo](https://github.com/m-lab/prometheus-support/pull/161).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/180)
<!-- Reviewable:end -->
