### PR TITLE
Filters ndt_raw and ndt_ssl targets to only include those particular to each project.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -66,7 +66,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:3001 \
           --label service=ndt_raw \
           --label module=tcp_v4_online \
-          --select="ndt.iupui.*" > \
+          --select="ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt_raw.json
 
       # NDT SSL on port 3010.
@@ -75,8 +75,22 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --label service=ndt_ssl \
           --label module=tcp_v4_tls_online \
           --use_flatnames \
-          --select="ndt.iupui.*" > \
+          --select="ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt_ssl.json
+
+      # script_exporter for NDT end-to-end monitoring
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}} \
+          --label service=ndt_e2e \
+          --select="ndt.iupui.(${!pattern})" > \
+              ${output}/script-targets/ndt_e2e.json
+
+      # script_exporter for NDT queueing check
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}} \
+          --label service=ndt_queue \
+          --select="ndt.iupui.(${!pattern})" > \
+              ${output}/script-targets/ndt_queue.json
 
       # Mobiperf on ports 6001, 6002, 6003.
       ./mlabconfig.py --format=prom-targets \
@@ -115,20 +129,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:9100 \
           --label service=nodeexporter \
               ${output}/legacy-targets/nodeexporter.json
-
-      # script_exporter for NDT end-to-end monitoring
-      ./mlabconfig.py --format=prom-targets \
-          --template_target={{hostname}} \
-          --label service=ndt_e2e \
-          --select="ndt.iupui.(${!pattern})" > \
-              ${output}/script-targets/ndt_e2e.json
-
-      # script_exporter for NDT queueing check
-      ./mlabconfig.py --format=prom-targets \
-          --template_target={{hostname}} \
-          --label service=ndt_queue \
-          --select="ndt.iupui.(${!pattern})" > \
-              ${output}/script-targets/ndt_queue.json
 
     else
       echo "Unknown group name: ${GROUP} for ${project}"


### PR DESCRIPTION
Having some of the NDT metrics in say, sandbox, for every node while others are only for testing nodes makes it very difficult to write sane dashboards that can be exported as "code" and moved between projects. This PR just standardizes on filtering all NDT targets to only include those particular to each project. In this way, we don't need to specify `machine=~<pattern>` in our Prom queries.

Also, group all NDT-related target generators together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/188)
<!-- Reviewable:end -->
