### PR TITLE
Changes target generation script to only generate per-project targets.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -44,7 +44,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:806 \
           --label service=ssh806 \
           --label module=ssh_v4_online \
-          --select="${!pattern}" > ${output}/blackbox-targets/ssh806.json
+          --select "${!pattern}" > ${output}/blackbox-targets/ssh806.json
 
       # Sidestream exporter in the npad experiment.
       ./mlabconfig.py --format=prom-targets \
@@ -66,7 +66,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:3001 \
           --label service=ndt_raw \
           --label module=tcp_v4_online \
-          --select="ndt.iupui.(${!pattern})" > \
+          --select "ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt_raw.json
 
       # NDT SSL on port 3010.
@@ -75,21 +75,21 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --label service=ndt_ssl \
           --label module=tcp_v4_tls_online \
           --use_flatnames \
-          --select="ndt.iupui.(${!pattern})" > \
+          --select "ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt_ssl.json
 
       # script_exporter for NDT end-to-end monitoring
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}} \
           --label service=ndt_e2e \
-          --select="ndt.iupui.(${!pattern})" > \
+          --select "ndt.iupui.(${!pattern})" > \
               ${output}/script-targets/ndt_e2e.json
 
       # script_exporter for NDT queueing check
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}} \
           --label service=ndt_queue \
-          --select="ndt.iupui.(${!pattern})" > \
+          --select "ndt.iupui.(${!pattern})" > \
               ${output}/script-targets/ndt_queue.json
 
       # Mobiperf on ports 6001, 6002, 6003.
@@ -99,7 +99,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:6003 \
           --label service=mobiperf \
           --label module=tcp_v4_online \
-          --select="1.michigan.*" > \
+          --select "1.michigan.(${!pattern})" > \
               ${output}/blackbox-targets/mobiperf.json
 
       # neubot on port 9773.
@@ -107,7 +107,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:9773/sapi/state \
           --label service=neubot \
           --label module=neubot_online \
-          --select="neubot.mlab.*" > \
+          --select "neubot.mlab.(${!pattern})" > \
               ${output}/blackbox-targets/neubot.json
 
       # snmp_exporter on port 9116.
@@ -121,13 +121,14 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:9393 \
           --label service=inotify \
-          --select="ndt.iupui.*" > \
+          --select "ndt.iupui.(${!pattern})" > \
               ${output}/legacy-targets/ndt_inotify.json
 
       # node_exporter on port 9100.
       ./mlabconfig.py --format=prom-targets-nodes \
           --template_target={{hostname}}:9100 \
           --label service=nodeexporter \
+          --select "${!pattern}" > \
               ${output}/legacy-targets/nodeexporter.json
 
     else


### PR DESCRIPTION
Currently, for some metrics, we generate targets for every node/service for every project. For example, for mobiperf blackbox_exporter we generate targets for every single node in mlab-oti, mlab-staging and mlab-sandbox. Yet for other probes (e.g., ndt_e2e script_exporter) we only generate targets for testing machines in mlab-sandbox, only mlab4s in mlab-staging, and only mlab[1-3] in mlab-oti. This is inconsistent target generation, and it makes writing dashboards in Grafana (and query Prometheus) manually confusing and problematic because you never know which set of targets are being probed in any given GCP project.

This PR normalizes targets for *every* set of targets we generate. After this PR, targets will only generated like this:

* mlab-oti project:   only mlab[1-3]s
* mlab-staging project: only mlab4s
* mlab-sandbox project: only testing nodes (sites that end in `t`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/192)
<!-- Reviewable:end -->
