### PR TITLE
Adds web100_enable_attr back to mlab_diff slice

### DIFF
--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -56,7 +56,6 @@ centos_slice_attrs += [ Attr('MeasurementLabCentos', isolate_loopback='1') ]
 #   http://man7.org/linux/man-pages/man7/capabilities.7.html
 # VServer configuration hints: 
 #   http://www.nongnu.org/util-vserver/doc/conf/configuration.html
-web100_enable_attr = [ Attr('MeasurementLabCentos', capabilities='vxc_^28') ]
 
 
 mlab4s_only = ['mlab4.nuq01', 'mlab4.nuq02', 'mlab4.prg01', 
@@ -69,7 +68,8 @@ mlab4s_only = ['mlab4.nuq01', 'mlab4.nuq02', 'mlab4.prg01',
 #         (and thus their IPs), it is not possible from inside one vm to see
 #         what ports are occupied by the other vm. Connection attempts to bind
 #         just fail.
-# attr  : a list of slice attributes.
+# attrs  : a list of slice attributes. NOTE: only a single Attr() can have a
+#          'capabilities' option defined.
 # users : a list of users to add to the slice.  this is supported primarily
 #         to allow non-admin users to generate dns information by collecting the
 #         slice attributes of configured slices.
@@ -86,11 +86,12 @@ mlab4s_only = ['mlab4.nuq01', 'mlab4.nuq02', 'mlab4.prg01',
 #            "all" - assign ipv6 addresses to all machines
 #         If a site lacks IPv6 addresses, none will be assigned even if "all" is
 #         given. For example, see lca01+npad.
+
 slice_list = [
 
-    Slice(name='iupui_ndt',       index=1, attrs=centos_slice_attrs+web100_enable_attr+[
-                                                Attr('MeasurementLabCentos',    disk_max='100000000'),  # 100GB.
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), ],
+    Slice(name='iupui_ndt',       index=1, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', disk_max='100000000'),  # 100GB.
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ],
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6=['mlab1.lax01', 'mlab1.mia03', 'mlab1.ham01', 'mlab1.hnd01',
@@ -98,48 +99,51 @@ slice_list = [
                                                  'iad05', 'iad0t', 'iad1t', 'lax02', 'lga07', 'lhr03', 'mia01',
                                                  'mil02', 'nuq04', 'par04', 'prg05', 'ord05', 'sea05',],
                                            rsync_modules=['ndt']),
-    Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+web100_enable_attr+[
-                                                Attr('MeasurementLabCentos',    disk_max='10000000'),
+    Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', disk_max='10000000'),
+                                                Attr('MeasurementLabCentos', capabilities='vxc_^28'),
                                                 Attr(None,    vsys='web100_proc_write'), ],
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6="all",
                                            rsync_modules=['sidestream', 'npad', 'paris-traceroute']),
-    Slice(name="mlab_diff",       index=4, attrs=centos_slice_attrs+web100_enable_attr+[
-                                                Attr('MeasurementLabCentos',    disk_max='100000000'),  # 100GB.
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE, CAP_NET_RAW'), ],
+    Slice(name="mlab_diff",       index=4, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', disk_max='100000000'),  # 100GB.
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE, CAP_NET_RAW, vxc_^28'), ],
                                            users=user_list,
                                            ipv6="all"),
-    Slice(name="uw_geoloc4",      index=5, attrs=centos_slice_attrs+web100_enable_attr, 
+    Slice(name="uw_geoloc4",      index=5, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', capabilities='vxc_^28'), ],
                                            users=user_list,
                                            ipv6=mlab4s_only + ['mlab4.ath03', 'mlab4.mnl01', 'mlab4.nuq1t', 'mlab4.dfw02']),
     Slice(name="mlab_ooni",       index=6, attrs=centos_slice_attrs+[
-                                                #Attr(None,      capabilities='CAP_NET_BIND_SERVICE,CAP_NET_RAW') ], 
                                                 Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,CAP_NET_RAW') ], 
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6="all",
                                            rsync_modules=['ooni']),
-    Slice(name="samknows_ispmon", index=7, attrs=centos_slice_attrs+web100_enable_attr,
+    Slice(name="samknows_ispmon", index=7, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', capabilities='vxc_^28'), ],
                                            users=user_list,
                                            ipv6="all"),
-    Slice(name="gt_bismark",      index=8, attrs=centos_slice_attrs+web100_enable_attr+[
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), ],
+    Slice(name="gt_bismark",      index=8, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE, vxc_^28'), ],
                                            users=user_list,
                                            ipv6=mlab4s_only),
-    Slice(name="mlab_neubot",     index=9, attrs=centos_slice_attrs+web100_enable_attr+[
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), ],
+    Slice(name="mlab_neubot",     index=9, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE, vxc_^28'), ],
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6="all",
                                            rsync_modules=['neubot']),
-    Slice(name="michigan_1",      index=10, attrs=centos_slice_attrs+web100_enable_attr, 
+    Slice(name="michigan_1",      index=10, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', capabilities='vxc_^28'), ],
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6="all"),
 
-    Slice(name='mlab_utility',    index=11, attrs=centos_slice_attrs+web100_enable_attr+[
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), 
+    Slice(name='mlab_utility',    index=11, attrs=centos_slice_attrs+[
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE, vxc_^28'),
                                                 Attr(None, vsys='vs_resource_backend') ],
                                             users=user_list,
                                             use_initscript=True,

--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -88,9 +88,9 @@ mlab4s_only = ['mlab4.nuq01', 'mlab4.nuq02', 'mlab4.prg01',
 #         given. For example, see lca01+npad.
 slice_list = [
 
-    Slice(name='iupui_ndt',       index=1, attrs=centos_slice_attrs+[
+    Slice(name='iupui_ndt',       index=1, attrs=centos_slice_attrs+web100_enable_attr+[
                                                 Attr('MeasurementLabCentos',    disk_max='100000000'),  # 100GB.
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ], 
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), ],
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6=['mlab1.lax01', 'mlab1.mia03', 'mlab1.ham01', 'mlab1.hnd01',
@@ -105,7 +105,7 @@ slice_list = [
                                            use_initscript=True,
                                            ipv6="all",
                                            rsync_modules=['sidestream', 'npad', 'paris-traceroute']),
-    Slice(name="mlab_diff",       index=4, attrs=centos_slice_attrs+[
+    Slice(name="mlab_diff",       index=4, attrs=centos_slice_attrs+web100_enable_attr+[
                                                 Attr('MeasurementLabCentos',    disk_max='100000000'),  # 100GB.
                                                 Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE, CAP_NET_RAW'), ],
                                            users=user_list,
@@ -123,12 +123,12 @@ slice_list = [
     Slice(name="samknows_ispmon", index=7, attrs=centos_slice_attrs+web100_enable_attr,
                                            users=user_list,
                                            ipv6="all"),
-    Slice(name="gt_bismark",      index=8, attrs=centos_slice_attrs+[
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ], 
+    Slice(name="gt_bismark",      index=8, attrs=centos_slice_attrs+web100_enable_attr+[
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), ],
                                            users=user_list,
                                            ipv6=mlab4s_only),
-    Slice(name="mlab_neubot",     index=9, attrs=centos_slice_attrs+[
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ], 
+    Slice(name="mlab_neubot",     index=9, attrs=centos_slice_attrs+web100_enable_attr+[
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), ],
                                            users=user_list,
                                            use_initscript=True,
                                            ipv6="all",
@@ -138,8 +138,8 @@ slice_list = [
                                            use_initscript=True,
                                            ipv6="all"),
 
-    Slice(name='mlab_utility',    index=11, attrs=centos_slice_attrs+[
-                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), 
+    Slice(name='mlab_utility',    index=11, attrs=centos_slice_attrs+web100_enable_attr+[
+                                                Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE'), 
                                                 Attr(None, vsys='vs_resource_backend') ],
                                             users=user_list,
                                             use_initscript=True,


### PR DESCRIPTION
I ignorantly removed the `web100_enable_attr` attribute from the mlab_diff slice in PR #196. Apparently this is necessary for Sidestream to be able to function properly and we want to have Sidestream collect data for all slices (except, OONI, apparently).

The file was also making inconsistent use of this attribute, which this PR also fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/197)
<!-- Reviewable:end -->
