### PR TITLE
Removes sites BOG01 and BKK01, as they are being retired.

### DIFF
--- a/plsync/sites.py
+++ b/plsync/sites.py
@@ -83,8 +83,6 @@ site_list = [
     makesite('ath03','193.201.166.128', '2001:648:25e0::',     'Athens', 'GR', 37.936400, 23.944400, user_list, count=4, v6gw='2001:648:25e0::129', nodegroup='MeasurementLabCentos'),
     makesite('bcn01','91.213.30.192',   '2001:67c:137c:5::',   'Barcelona', 'ES', 41.297445, 2.081105, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('beg01','188.120.127.0',  '2001:7f8:1e:6::',      'Belgrade', 'RS', 44.821600, 20.292100, user_list, nodegroup='MeasurementLabCentos'),
-    makesite('bkk01','61.7.252.0',     '2001:c38:9041::',      'Bangkok', 'TH', 13.690400, 100.750100, user_list, arch='x86_64', nodegroup='MeasurementLabCentos'),
-    makesite('bog01','190.15.11.0',    None,                   'Bogota', 'CO', 4.5833, -74.066700, user_list, exclude=[1,2,3], nodegroup='MeasurementLabCentos'),
     makesite('bom01','125.18.112.64',  '2404:a800:2000:217::', 'Mumbai', 'IN', 19.088611, 72.868056, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('bru01','195.89.146.128', '2001:5005:200::',      'Brussels', 'BE', 50.4974163, 3.3528346, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),
     makesite('bru02','212.3.248.192',  '2001:4c08:2003:45::',  'Brussels', 'BE', 50.4974163, 3.3528346, user_list, count=4, arch='x86_64-r630', nodegroup='MeasurementLabCentos'),


### PR DESCRIPTION
BOG01 has been down for over a year, and the site host has been completely unresponsive and unhelpful. We've given up on this site.

BKK01 was a site sponsored by NBTC in Thailand with CAT Telecom for a period of, I think, 3 years. That time expired and the equipment was turned down by CAT Telecom a month or so ago. This site is done, but we will seek out other relationships in Thailand, possibly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/204)
<!-- Reviewable:end -->
