### PR TITLE
Adds ability to specify that you want protocol decorated hostnames

### DIFF
--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -238,8 +238,8 @@ def parse_flags():
         '',
         '--decoration',
         dest='decoration',
-        default=None,
-        choices=[None, 'v4', 'v6'],
+        default='',
+        choices=['', 'v4', 'v6'],
         help='Protocol decoration for Prom targets (e.g, mlab1v4.abc01).')
     parser.add_option(
         '',
@@ -691,12 +691,7 @@ def select_prometheus_experiment_targets(experiments, select_regex,
             labels['experiment'] = experiment.dnsname()
             labels['machine'] = node.hostname()
 
-            # "Decorated" domain names specify the protocol (v4 or v6) in the
-            # name (e.g., mlab1v4.abc01, mlab2v6.lol02).
-            if decoration:
-                host = experiment.hostname(node, decoration)
-            else:
-                host = experiment.hostname(node)
+            host = experiment.hostname(node, decoration)
 
             # Don't use the flatten_hostname() function in this module because
             # it adds too much overhead. Just replace the first three dots with
@@ -746,12 +741,7 @@ def select_prometheus_node_targets(sites, select_regex, target_templates,
             labels['machine'] = node.hostname()
             targets = []
 
-            # "Decorated" domain names specify the protocol (v4 or v6) in the
-            # name (e.g., mlab1v4.abc01, mlab2v6.lol02).
-            if decoration:
-                host = node.hostname(decoration)
-            else:
-                host = node.hostname()
+            host = node.hostname(decoration)
 
             for tmpl in target_templates:
                 target_tmpl = BracketTemplate(tmpl)

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -660,7 +660,7 @@ def export_scraper_kubernetes_config(filename_template, experiments,
 def select_prometheus_experiment_targets(experiments, select_regex,
                                          target_templates, common_labels,
                                          rsync_only, use_flatnames,
-                                         decoration, domain):
+                                         decoration):
     """Selects and formats targets from experiments.
 
     Args:
@@ -675,7 +675,6 @@ def select_prometheus_experiment_targets(experiments, select_regex,
           wildcard certificates.
       decoration: str, return protocol 'decorated' host names
           (e.g., mlab1v6.abc01).
-      domain: str, the default domain for all DNS host names.
 
     Returns:
       list of dict, each element is a dict with 'labels' (a dict of key/values)
@@ -695,8 +694,7 @@ def select_prometheus_experiment_targets(experiments, select_regex,
             # "Decorated" domain names specify the protocol (v4 or v6) in the
             # name (e.g., mlab1v4.abc01, mlab2v6.lol02).
             if decoration:
-                host = '%s.%s' % (experiment.recordname(node, decoration),
-                                  domain)
+                host = experiment.hostname(node, decoration)
             else:
                 host = experiment.hostname(node)
 
@@ -722,7 +720,7 @@ def select_prometheus_experiment_targets(experiments, select_regex,
 
 
 def select_prometheus_node_targets(sites, select_regex, target_templates,
-                                   common_labels, decoration, domain):
+                                   common_labels, decoration):
     """Selects and formats targets from site nodes.
 
     Args:
@@ -734,7 +732,6 @@ def select_prometheus_node_targets(sites, select_regex, target_templates,
       common_labels: dict of str, a set of labels to apply to all targets.
       decoration: str, used to "decorate" the hostname with a protocol
           (e.g., mlab1v6.abc01).
-      domain: str, the default domain for all DNS host names.
 
     Returns:
       list of dict, each element is a dict with 'labels' (a dict of key/values)
@@ -752,7 +749,7 @@ def select_prometheus_node_targets(sites, select_regex, target_templates,
             # "Decorated" domain names specify the protocol (v4 or v6) in the
             # name (e.g., mlab1v4.abc01, mlab2v6.lol02).
             if decoration:
-                host = '%s.%s' % (node.recordname(decoration), domain)
+                host = node.hostname(decoration)
             else:
                 host = node.hostname()
 
@@ -843,13 +840,13 @@ def main():
         records = select_prometheus_experiment_targets(
             experiments, options.select, options.template_target,
             options.labels, options.rsync, options.use_flatnames,
-            options.decoration, options.domain)
+            options.decoration)
         json.dump(records, sys.stdout, indent=4)
 
     elif options.format == 'prom-targets-nodes':
         records = select_prometheus_node_targets(
             sites, options.select, options.template_target, options.labels,
-            options.decoration, options.domain)
+            options.decoration)
         json.dump(records, sys.stdout, indent=4)
 
     elif options.format == 'prom-targets-sites':

--- a/plsync/planetlab/model.py
+++ b/plsync/planetlab/model.py
@@ -390,9 +390,9 @@ class Node(dict):
     def v6gw(self):
         return self['net']['v6'].ipv6_defaultgw()
 
-    def hostname(self):
+    def hostname(self, decoration=''):
         """Returns the Node FQDN."""
-        return '%s.%s' % (self.recordname(), MLAB_ORG_DOMAIN)
+        return '%s.%s' % (self.recordname(decoration), MLAB_ORG_DOMAIN)
 
     def recordname(self, decoration=''):
         """Returns the Node resource record, e.g. hostname without domain."""
@@ -593,9 +593,9 @@ class Slice(dict):
         # When a name has multiple '_', rejoin all parts after the group name.
         return '.'.join(fields[1:] + fields[:1])
 
-    def hostname(self, node):
+    def hostname(self, node, decoration=''):
         """Returns the FQDN for a slice on the given node."""
-        return '.'.join((self.dnsname(), node.hostname()))
+        return '%s.%s' % (self.recordname(node, decoration), MLAB_ORG_DOMAIN)
 
     def recordname(self, server, decoration=''):
         """Returns the Slice resource record, e.g. hostname without domain."""


### PR DESCRIPTION
Currently, mlabconfig.py generates only non-protocol-decorated hostnames when generating Prometheus targets. This PR adds a new `--decoration` flag that allows you to specify that you want experiment or node hostnames decorated with either `v4` or `v6`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/208)
<!-- Reviewable:end -->
