### PR TITLE
Generate IPv6 targets, and fix a bug in the target generation script.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -92,7 +92,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select "ndt.iupui.(${!pattern})" > \
               ${output}/script-targets/ndt_queue.json
 
-      # Mobiperf on ports 6001, 6002, 6003.
+      # Mobiperf on ports 6001, 6002, 6003 over IPv4.
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:6001 \
           --template_target={{hostname}}:6002 \
@@ -102,13 +102,32 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select "1.michigan.(${!pattern})" > \
               ${output}/blackbox-targets/mobiperf.json
 
-      # neubot on port 9773.
+      # Mobiperf on ports 6001, 6002, 6003 over IPv6.
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}}:6001 \
+          --template_target={{hostname}}:6002 \
+          --template_target={{hostname}}:6003 \
+          --label service=mobiperf_ipv6 \
+          --label module=tcp_v6_online \
+          --select "1.michigan.(${!pattern})" > \
+              ${output}/blackbox-targets/mobiperf_ipv6.json
+
+
+      # neubot on port 9773 over IPv4.
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:9773/sapi/state \
           --label service=neubot \
-          --label module=neubot_online \
+          --label module=neubot_online_v4 \
           --select "neubot.mlab.(${!pattern})" > \
               ${output}/blackbox-targets/neubot.json
+
+      # neubot on port 9773 over IPv6.
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}}:9773/sapi/state \
+          --label service=neubot_ipv6 \
+          --label module=neubot_online_v6 \
+          --select "neubot.mlab.(${!pattern})" > \
+              ${output}/blackbox-targets/neubot_ipv6.json
 
       # snmp_exporter on port 9116.
       ./mlabconfig.py --format=prom-targets-sites \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -63,7 +63,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:806 \
           --label service=ssh806 \
           --label module=ssh_v6_online \
-          --label _blackbox_port=${!bbe_port} \
+          --label __blackbox_port=${!bbe_port} \
           --select "${!pattern}" \
           --decoration "v6" > ${output}/blackbox-targets/ssh806_ipv6.json
 
@@ -130,7 +130,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:6003 \
           --label service=mobiperf_ipv6 \
           --label module=tcp_v6_online \
-          --label _blackbox_port=${!bbe_port} \
+          --label __blackbox_port=${!bbe_port} \
           --select "1.michigan.(${!pattern})" \
           --decoration "v6" > ${output}/blackbox-targets/mobiperf_ipv6.json
 
@@ -147,7 +147,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:9773/sapi/state \
           --label service=neubot_ipv6 \
           --label module=neubot_online_v6 \
-          --label _blackbox_port=${!bbe_port} \
+          --label __blackbox_port=${!bbe_port} \
           --select "neubot.mlab.(${!pattern})" \
           --decoration "v6" > ${output}/blackbox-targets/neubot_ipv6.json
 

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -51,7 +51,8 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:806 \
           --label service=ssh806 \
           --label module=ssh_v6_online \
-          --select "${!pattern}" > ${output}/blackbox-targets/ssh806_ipv6.json
+          --select "${!pattern}" \
+          --decoration "v6" > ${output}/blackbox-targets/ssh806_ipv6.json
 
       # Sidestream exporter in the npad experiment.
       ./mlabconfig.py --format=prom-targets \
@@ -116,8 +117,8 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:6003 \
           --label service=mobiperf_ipv6 \
           --label module=tcp_v6_online \
-          --select "1.michigan.(${!pattern})" > \
-              ${output}/blackbox-targets/mobiperf_ipv6.json
+          --select "1.michigan.(${!pattern})" \
+          --decoration "v6" > ${output}/blackbox-targets/mobiperf_ipv6.json
 
 
       # neubot on port 9773 over IPv4.
@@ -133,8 +134,8 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --template_target={{hostname}}:9773/sapi/state \
           --label service=neubot_ipv6 \
           --label module=neubot_online_v6 \
-          --select "neubot.mlab.(${!pattern})" > \
-              ${output}/blackbox-targets/neubot_ipv6.json
+          --select "neubot.mlab.(${!pattern})" \
+          --decoration "v6" > ${output}/blackbox-targets/neubot_ipv6.json
 
       # snmp_exporter on port 9116.
       ./mlabconfig.py --format=prom-targets-sites \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -39,12 +39,19 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --rsync \
           --select "${!pattern}" > ${output}/blackbox-targets/rsyncd.json
 
-      # SSH on port 806.
+      # SSH on port 806 over IPv4
       ./mlabconfig.py --format=prom-targets-nodes \
           --template_target={{hostname}}:806 \
           --label service=ssh806 \
           --label module=ssh_v4_online \
           --select "${!pattern}" > ${output}/blackbox-targets/ssh806.json
+
+      # SSH on port 806 over IPv6
+      ./mlabconfig.py --format=prom-targets-nodes \
+          --template_target={{hostname}}:806 \
+          --label service=ssh806 \
+          --label module=ssh_v6_online \
+          --select "${!pattern}" > ${output}/blackbox-targets/ssh806_ipv6.json
 
       # Sidestream exporter in the npad experiment.
       ./mlabconfig.py --format=prom-targets \

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -691,18 +691,20 @@ def select_prometheus_experiment_targets(experiments, select_regex,
             labels['experiment'] = experiment.dnsname()
             labels['machine'] = node.hostname()
 
-            host = experiment.hostname(node, decoration)
-
-            # Don't use the flatten_hostname() function in this module because
-            # it adds too much overhead. Just replace the first three dots with
-            # dashes.
-            if use_flatnames:
-                host = host.replace('.', '-', 3)
             # Consider all experiments or only those with rsync modules.
             if not rsync_only or experiment['rsync_modules']:
-                if select_regex and not re.search(select_regex, host):
+                if select_regex and not re.search(select_regex, experiment.hostname(node)):
                     continue
                 targets = []
+
+                host = experiment.hostname(node, decoration)
+
+                # Don't use the flatten_hostname() function in this module because
+                # it adds too much overhead. Just replace the first three dots with
+                # dashes.
+                if use_flatnames:
+                    host = host.replace('.', '-', 3)
+
                 for tmpl in target_templates:
                     target_tmpl = BracketTemplate(tmpl)
                     target = target_tmpl.safe_substitute({'hostname': host})


### PR DESCRIPTION
A chunk of the changes to *generate_prometheus_targets.sh* are pretty much the same ones that were already approved in closed PR #205, with the exception that we now take advantage to the new `--decoration` flag to for those IPv6 targets so that it's IPv6 or nothing (the check can't fall back on IPv4 for any reason).

Additionally, a new label is added to all blackbox_exporter IPv6 targets name `_blackbox_port` which contains the port of the instance of blackbox_exporter running on our Linode VM which should be queried for that project.

Additional, I discovered bug in *mlabconfig.py* in the  `select_prometheus_experiment_targets()` functions where decorating and flattening of domain names was happening *before* regex filtering was happening, and the regex patterns we are using aren't configured to match the decorated or flattened domain names. The change simply moves any decorating and flattening *after* the filtering to avoid having to account for decorations and flattened names in the regexes.  This wasn't a problem in `select_prometheus_node_targets()` because that function already had the modifications happening after the filtering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/209)
<!-- Reviewable:end -->
