### PR TITLE
Restore unit tests for hostips and sitestats

### DIFF
--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -786,8 +786,8 @@ def main():
     if options.format == 'hostips':
         output = export_mlab_host_ips(sites, experiments)
         sys.stdout.write(output.getvalue())
-        # Temporary workaround for HND01 load issues. Remove this after the
-        # issue has been resolved.
+        # Temporary workaround for HND01 load issues. Remove or generalize:
+        # https://github.com/m-lab/operator/issues/154
         sys.stdout.write(
             'mlab1.tyo01.measurement-lab.org,35.200.102.226,\n'
             'ndt.iupui.mlab1.tyo01.measurement-lab.org,35.200.102.226,\n'

--- a/plsync/mlabconfig.py
+++ b/plsync/mlabconfig.py
@@ -499,7 +499,7 @@ def export_mlab_zone_header(output, header, options):
     output.write(headerdata)
 
 
-def export_mlab_site_stats(output, sites):
+def export_mlab_site_stats(sites):
     sitestats = []
     for site in sites:
         name = site['name']
@@ -523,23 +523,12 @@ def export_mlab_site_stats(output, sites):
             'roundrobin': site.get('roundrobin', False)
         })
 
-    # Temporary workaround for HND01 load issues. Remove this after the issue
-    # has been resolved.
-    for tyo in ['tyo01', 'tyo02', 'tyo03']:
-        sitestats.append({
-            'site': tyo,
-            'metro': [tyo, tyo[:-2]],
-            'city': 'Tokyo',
-            'country': 'JP',
-            'latitude': 35.552200,
-            'longitude': 139.780000
-        })
-
-    json.dump(sitestats, output)
+    return sitestats
 
 
-def export_mlab_host_ips(output, sites, experiments):
+def export_mlab_host_ips(sites, experiments):
     """Writes csv data of all M-Lab servers and experiments to output."""
+    output = StringIO.StringIO()
     # Export server names and addresses.
     for site in sites:
         # TODO(soltesz): change 'nodes' to be a sorted list of node objects.
@@ -559,17 +548,7 @@ def export_mlab_host_ips(output, sites, experiments):
                                                 ipv4=experiment.ipv4(node),
                                                 ipv6=experiment.ipv6(node)))
 
-    # Temporary workaround for HND01 load issues. Remove this after the
-    # issue has been resolved.
-    output.write(
-       'mlab1.tyo01.measurement-lab.org,35.200.102.226,\n'
-       'ndt.iupui.mlab1.tyo01.measurement-lab.org,35.200.102.226,\n'
-       'mlab1.tyo02.measurement-lab.org,35.200.34.149,\n'
-       'ndt.iupui.mlab1.tyo02.measurement-lab.org,35.200.34.149,\n'
-       'mlab1.tyo03.measurement-lab.org,35.200.112.17,\n'
-       'ndt.iupui.mlab1.tyo03.measurement-lab.org,35.200.112.17,\n'
-    )
-
+    return output
 
 
 # TODO(soltesz): this function is too specific to node network configuration.
@@ -805,10 +784,36 @@ def main():
                 experiment.add_node_address(node)
 
     if options.format == 'hostips':
-        export_mlab_host_ips(sys.stdout, sites, experiments)
+        output = export_mlab_host_ips(sites, experiments)
+        sys.stdout.write(output.getvalue())
+        # Temporary workaround for HND01 load issues. Remove this after the
+        # issue has been resolved.
+        sys.stdout.write(
+            'mlab1.tyo01.measurement-lab.org,35.200.102.226,\n'
+            'ndt.iupui.mlab1.tyo01.measurement-lab.org,35.200.102.226,\n'
+            'mlab1.tyo02.measurement-lab.org,35.200.34.149,\n'
+            'ndt.iupui.mlab1.tyo02.measurement-lab.org,35.200.34.149,\n'
+            'mlab1.tyo03.measurement-lab.org,35.200.112.17,\n'
+            'ndt.iupui.mlab1.tyo03.measurement-lab.org,35.200.112.17,\n'
+        )
 
     elif options.format == 'sitestats':
-        export_mlab_site_stats(sys.stdout, sites)
+        sitestats = export_mlab_site_stats(sites)
+
+        # Temporary workaround for HND01 load issues. Remove or generalize:
+        # https://github.com/m-lab/operator/issues/154
+        for tyo in ['tyo01', 'tyo02', 'tyo03']:
+            sitestats.append({
+                'site': tyo,
+                'metro': [tyo, tyo[:-2]],
+                'city': 'Tokyo',
+                'country': 'JP',
+                'latitude': 35.552200,
+                'longitude': 139.780000,
+                'roundrobin': False
+            })
+
+        json.dump(sitestats, sys.stdout)
 
     elif options.format == 'server-network-config':
         with open(options.template) as template:

--- a/plsync/mlabconfig_test.py
+++ b/plsync/mlabconfig_test.py
@@ -128,24 +128,23 @@ class MlabconfigTest(unittest.TestCase):
              '2400:1002:4008::37'),
         ]
 
-        mlabconfig.export_mlab_host_ips(output, self.sites, experiments)
+        output = mlabconfig.export_mlab_host_ips(self.sites, experiments)
 
         results = output.getvalue().split()
-        #self.assertItemsEqual(results, expected_results)
+        self.assertItemsEqual(results, expected_results)
 
     def test_export_mlab_site_stats(self):
-        output = StringIO.StringIO()
         expected_results = [{"city": "Some City",
                              "metro": ["abc01", "abc"],
                              "country": "US",
                              "site": "abc01",
                              "longitude": 74.783,
-                             "latitude": 36.85}]
+                             "latitude": 36.85,
+                             "roundrobin": False}]
 
-        mlabconfig.export_mlab_site_stats(output, self.sites)
+        sitestats = mlabconfig.export_mlab_site_stats(self.sites)
 
-        results = json.loads(output.getvalue())
-        #self.assertItemsEqual(results, expected_results)
+        self.assertItemsEqual(sitestats, expected_results)
 
     def test_export_router_and_switch_records(self):
         output = StringIO.StringIO()


### PR DESCRIPTION
This change restores all unit tests to mlabconfig sitestats and hostips. This changes the interfaces to `export_mlab_site_stats` and `export_mlab_host_ips` to return values that are handled by the callers rather than written unconditionally to stdout. This makes the unit tests a little simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/213)
<!-- Reviewable:end -->
