### PR TITLE
Add generation and upload of metadata configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ deploy:
 - provider: script
   script: $TRAVIS_BUILD_DIR/deploy_metadata_configs.sh
       SERVICE_ACCOUNT_mlab_sandbox
-      $TRAVIS_BUILD_DIR/gen/mlab-sandbox
+      $TRAVIS_BUILD_DIR/gen/mlab-sandbox/metadata
       gs://operator-mlab-sandbox/metadata/v0
   skip_cleanup: true
   on:
@@ -76,7 +76,7 @@ deploy:
 - provider: script
   script: $TRAVIS_BUILD_DIR/deploy_metadata_configs.sh
       SERVICE_ACCOUNT_mlab_staging
-      $TRAVIS_BUILD_DIR/gen/mlab-staging
+      $TRAVIS_BUILD_DIR/gen/mlab-staging/metadata
       gs://operator-mlab-staging/metadata/v0
   skip_cleanup: true
   on:
@@ -97,7 +97,7 @@ deploy:
 - provider: script
   script: $TRAVIS_BUILD_DIR/deploy_metadata_configs.sh
       SERVICE_ACCOUNT_mlab_oti
-      $TRAVIS_BUILD_DIR/gen/mlab-oti
+      $TRAVIS_BUILD_DIR/gen/mlab-oti/metadata
       gs://operator-mlab-oti/metadata/v0
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,10 @@ deploy:
 
   # Deploy metadata configs.
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
-      $TRAVIS_BUILD_DIR/metadata/v0 gs://operator-mlab-sandbox/metadata/
+  script: $TRAVIS_BUILD_DIR/deploy_metadata_configs.sh
+      SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/gen/mlab-sandbox
+      gs://operator-mlab-sandbox/metadata/v0
   skip_cleanup: true
   on:
     repo: m-lab/operator
@@ -70,10 +72,33 @@ deploy:
     repo: m-lab/operator
     branch: master
 
+  # Deploy metadata configs.
+- provider: script
+  script: $TRAVIS_BUILD_DIR/deploy_metadata_configs.sh
+      SERVICE_ACCOUNT_mlab_staging
+      $TRAVIS_BUILD_DIR/gen/mlab-staging
+      gs://operator-mlab-staging/metadata/v0
+  skip_cleanup: true
+  on:
+    repo: m-lab/operator
+    all_branches: true
+    condition: $TRAVIS_BRANCH == master
+
 ############################################################################
 # Production, on tags.
 - provider: script
   script: $TRAVIS_BUILD_DIR/deploy_prometheus_targets.sh mlab-oti global
+  skip_cleanup: true
+  on:
+    repo: m-lab/operator
+    tags: true
+
+  # Deploy metadata configs.
+- provider: script
+  script: $TRAVIS_BUILD_DIR/deploy_metadata_configs.sh
+      SERVICE_ACCOUNT_mlab_oti
+      $TRAVIS_BUILD_DIR/gen/mlab-oti
+      gs://operator-mlab-oti/metadata/v0
   skip_cleanup: true
   on:
     repo: m-lab/operator

--- a/deploy_metadata_configs.sh
+++ b/deploy_metadata_configs.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
 #
-# deploy_metadata_configs.sh does some things.
+# deploy_metadata_configs.sh generates and archives standard M-Lab site, host,
+# and experiment configuration information.
+#
+# To prevent duplicates, archives are only updated when sites.py or slices.py
+# change. It is safe to run deploy_metadata_configs.sh multiple times.
+#
+# Example:
+#  ./deploy_metadata_configs.sh
+#      SERVICE_ACCOUNT_mlab_sandbox
+#      $TRAVIS_BUILD_DIR/gen/mlab-sandbox
+#      gs://operator-mlab-sandbox/metadata/v0
 
 set -eux
 set -o pipefail
 
 # Root directory of this script.
 SCRIPTDIR=$( dirname "${BASH_SOURCE[0]}" )
-USAGE="$0 <keyname> <outdir> gs://<bucket-prefix>"
+USAGE="$0 <keyname> <output-dir> <gs://bucket/and/path>"
 KEYNAME=${1:?Provide the service account keyname: $USAGE}
 OUTDIR=${2:?Provide an output directory name: $USAGE}
 BUCKET_TARGET=${3:?Provide an absolute GCS bucket and path for upload: $USAGE}
 
-# Create all output directories.
+############################################################################
+# Generate configs
+############################################################################
 mkdir -p ${OUTDIR}
 
 # Copy user configs.
@@ -21,27 +33,39 @@ cp -r ${SCRIPTDIR}/metadata/v0/users ${OUTDIR}/
 # TODO: Usage of .txt output is deprecated.
 ${SCRIPTDIR}/plsync/mlabconfig.py \
     --format=hostips > ${OUTDIR}/mlab-host-ips.txt
-
 # Export standard JSON configs for host addresses and site status.
 ${SCRIPTDIR}/plsync/mlabconfig.py \
     --format=hostips-json > ${OUTDIR}/mlab-host-ips.json
 ${SCRIPTDIR}/plsync/mlabconfig.py \
     --format=sitestats > ${OUTDIR}/mlab-site-stats.json
 
-# Use an archive date that equals the last commit date.
-ARCHIVE=$( date -d @`cd ${SCRIPTDIR}; git log -1 --format=%ct` +%Y-%m-%dT%H:%M:00Z )
+############################################################################
+# Upload and archive configs
+############################################################################
+
+# Archive date is the most recent commit time to slices.py or sites.py.
+TIMESTAMP=$( cd ${SCRIPTDIR}; \
+    for f in plsync/sites.py plsync/slices.py ; do \
+      git log -1 --format=%ct $f ; \
+    done | sort -nr | head -1)
+ARCHIVE=$( date -d @${TIMESTAMP} +%Y-%m-%dT%H:%M:%SZ )
+
+# Check whether the current ARCHIVE date already exists. If so, then a previous
+# deploy already uploaded it. If not, then we'll upload it below.
+if gsutil stat ${BUCKET_TARGET}/archive/${ARCHIVE}/mlab-site-stats.json ; then
+  echo "Skipping upload because the current archive is already up to date!"
+  exit 0
+fi
 
 # TODO: Remove any files from 'current' that we are not generating.
-# Get current list.
-# Upload new files.
-# Get new list.
-# Delete old files.
 
-# Upload "current" to GCS.
+# Upload generated files to "current" directory in GCS.
 ${SCRIPTDIR}/travis/deploy_gcs.sh \
-  ${KEYNAME} ${OUTDIR}/* ${BUCKET_TARGET}/current/
+  ${KEYNAME} \
+  ${OUTDIR}/* \
+  ${BUCKET_TARGET}/current/
 
-# Copy "current" to archive.
+# Create an archive copy of the new "current" directory.
 ${SCRIPTDIR}/travis/deploy_gcs.sh \
   ${KEYNAME} \
   ${BUCKET_TARGET}/current/* \

--- a/deploy_metadata_configs.sh
+++ b/deploy_metadata_configs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# deploy_metadata_configs.sh does some things.
+
+set -eux
+set -o pipefail
+
+# Root directory of this script.
+SCRIPTDIR=$( dirname "${BASH_SOURCE[0]}" )
+USAGE="$0 <keyname> <outdir> gs://<bucket-prefix>"
+KEYNAME=${1:?Provide the service account keyname: $USAGE}
+OUTDIR=${2:?Provide an output directory name: $USAGE}
+BUCKET_TARGET=${3:?Provide an absolute GCS bucket and path for upload: $USAGE}
+
+# Create all output directories.
+mkdir -p ${OUTDIR}
+
+# Copy user configs.
+cp -r ${SCRIPTDIR}/metadata/v0/users ${OUTDIR}/
+
+# TODO: Usage of .txt output is deprecated.
+${SCRIPTDIR}/plsync/mlabconfig.py \
+    --format=hostips > ${OUTDIR}/mlab-host-ips.txt
+
+# Export standard JSON configs for host addresses and site status.
+${SCRIPTDIR}/plsync/mlabconfig.py \
+    --format=hostips-json > ${OUTDIR}/mlab-host-ips.json
+${SCRIPTDIR}/plsync/mlabconfig.py \
+    --format=sitestats > ${OUTDIR}/mlab-site-stats.json
+
+# Use an archive date that equals the last commit date.
+ARCHIVE=$( date -d @`cd ${SCRIPTDIR}; git log -1 --format=%ct` +%Y-%m-%dT%H:%M:00Z )
+
+# TODO: Remove any files from 'current' that we are not generating.
+# Get current list.
+# Upload new files.
+# Get new list.
+# Delete old files.
+
+# Upload "current" to GCS.
+${SCRIPTDIR}/travis/deploy_gcs.sh \
+  ${KEYNAME} ${OUTDIR}/* ${BUCKET_TARGET}/current/
+
+# Copy "current" to archive.
+${SCRIPTDIR}/travis/deploy_gcs.sh \
+  ${KEYNAME} \
+  ${BUCKET_TARGET}/current/* \
+  ${BUCKET_TARGET}/archive/${ARCHIVE}/

--- a/deploy_metadata_configs.sh
+++ b/deploy_metadata_configs.sh
@@ -9,7 +9,7 @@
 # Example:
 #  ./deploy_metadata_configs.sh
 #      SERVICE_ACCOUNT_mlab_sandbox
-#      $TRAVIS_BUILD_DIR/gen/mlab-sandbox
+#      $TRAVIS_BUILD_DIR/gen/mlab-sandbox/output
 #      gs://operator-mlab-sandbox/metadata/v0
 
 set -eux


### PR DESCRIPTION
This change adds support for generating, publishing, and archiving M-Lab site, server, and experiment configurations.

To begin, we generate the canonical mlab-host-ips data in TXT and JSON format as well as the mlab-site-stats.json files. These files are only uploaded when sites.py or slices.py change.

As a result, the GCS bucket `gs://operator-<project>/metadata/v0/current/*` will always contain the most current configuration, and `gs://operator-<project>/metadata/v0/archive/*` will contain date-directories with past configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/219)
<!-- Reviewable:end -->
