### PR TITLE
Enables IPv6 for NDT everywhere.

### DIFF
--- a/plsync/slices.py
+++ b/plsync/slices.py
@@ -93,10 +93,7 @@ slice_list = [
                                                 Attr('MeasurementLabCentos', capabilities='CAP_NET_BIND_SERVICE,vxc_^28'), ],
                                            users=user_list,
                                            use_initscript=True,
-                                           ipv6=['mlab1.lax01', 'mlab1.mia03', 'mlab1.ham01', 'mlab1.hnd01',
-                                                 'arn03', 'atl02', 'bru03', 'den01', 'dfw01', 'fln01',
-                                                 'fra03', 'iad05', 'iad0t', 'iad1t', 'lax02', 'lga07', 'lhr03',
-                                                 'mia01', 'mil02', 'nuq04', 'par04', 'prg05', 'ord05', 'sea05',],
+                                           ipv6="all",
                                            rsync_modules=['ndt']),
     Slice(name='iupui_npad',      index=2, attrs=centos_slice_attrs+[
                                                 Attr('MeasurementLabCentos', disk_max='10000000'),


### PR DESCRIPTION
After discussing with Greg, Matt and Stephen in the data quality meeting today, we decided that the NDT IPv6 canary was successful and revealed no major concerns and that we are ready to enable IPv6 for NDT everywhere.