### PR TITLE
Handle cases when ipv6 is not enabled

### DIFF
--- a/plsync/planetlab/model.py
+++ b/plsync/planetlab/model.py
@@ -137,6 +137,7 @@ class NetworkIPv6(dict):
     def interface(self, index):
         """Returns a dict of typical interface values for IPv6."""
         return {
+            'ipv6_enabled': 'true',
             'ipv6_prefix': self['prefix'],
             'ipv6_address': self.ipv6addr(index),
             'ipv6_gateway': self.ipv6_defaultgw(),
@@ -392,7 +393,11 @@ class Node(dict):
     def interface(self):
         return self['net']['v4'].interface(self['index'])
     def interface_ipv6(self):
-        return self['net']['v6'].interface(self['index'])
+        if self.ipv6_is_enabled():
+            return self['net']['v6'].interface(self['index'])
+        else:
+            # TODO: create a NetworkIPv6 instance that returns this.
+            return {'ipv6_enabled': 'false'}
     def iplist(self):
         return self['net']['v4'].iplist(self['index'])
     def iplistv6(self):

--- a/plsync/planetlab/model_test.py
+++ b/plsync/planetlab/model_test.py
@@ -11,6 +11,10 @@ class ModelTest(unittest.TestCase):
         self.sites = [model.makesite(
             'abc01', '192.168.1.0', '2400:1002:4008::', 'Some City', 'US',
             36.850000, 74.783000, self.users, nodegroup='MeasurementLabCentos')]
+        self.sites_without_ipv6 = [model.makesite(
+            'abc01', '192.168.1.0', None, 'Some City', 'US',
+            36.850000, 74.783000, self.users, exclude=[1,2,3],
+            nodegroup='MeasurementLabCentos')]
         self.attrs = [model.Attr('MeasurementLabCentos', disk_max='60000000')]
         # Setup synthetic user, site, and experiment configuration data.
         self.experiments = [
@@ -170,6 +174,7 @@ class ModelTest(unittest.TestCase):
 
     def test_node_interface_ipv6(self):
         expected = {
+            'ipv6_enabled': 'true',
             'ipv6_prefix': '2400:1002:4008::',
             'ipv6_address': '2400:1002:4008::9',
             'ipv6_gateway': '2400:1002:4008::1',
@@ -177,6 +182,16 @@ class ModelTest(unittest.TestCase):
             'ipv6_dns2': '2001:4860:4860::8844',
         }
         node = self.sites[0]['nodes']['mlab1.abc01.measurement-lab.org']
+
+        actual = node.interface_ipv6()
+
+        self.assertItemsEqual(expected, actual)
+
+    def test_node_interface_ipv6_when_ipv6_disabled(self):
+        expected = {
+            'ipv6_enabled': 'false',
+        }
+        node = self.sites_without_ipv6[0]['nodes']['mlab1.abc01.measurement-lab.org']
 
         actual = node.interface_ipv6()
 


### PR DESCRIPTION
This change continues https://github.com/m-lab/operator/pull/233 by adding support for nodes without IPv6 enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/235)
<!-- Reviewable:end -->
