### PR TITLE
Adds a ping probe for platform switches

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -193,6 +193,12 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select "${!pattern}" > \
               ${output}/legacy-targets/nodeexporter.json
 
+      # ICMP probe for platform switches
+      ./mlabconfig.py --format=prom-targets-sites \
+          --template_target=s1.{{sitename}}.measurement-lab.org \
+          --label module=icmp > \
+              ${output}/blackbox-targets/switches_ping.json
+
     else
       echo "Unknown group name: ${GROUP} for ${project}"
     fi

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -175,8 +175,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       # snmp_exporter on port 9116.
       ./mlabconfig.py --format=prom-targets-sites \
           --template_target=s1.{{sitename}}.measurement-lab.org \
-          --label service=snmp \
-          --label __exporter_project=${project} > \
+          --label service=snmp > \
               ${output}/snmp-targets/snmpexporter.json
 
       # inotify_exporter for NDT on port 9393.


### PR DESCRIPTION
This probe will be at the top of the probe hierarchy for a pod. If a ping probe fails for a switch for long enough, then we should suppress all other alerts for related to that pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/236)
<!-- Reviewable:end -->
