### PR TITLE
Generate ssh.json and ssh_ipv6.json as targets.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -67,6 +67,22 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select "${!pattern}" \
           --decoration "v6" > ${output}/blackbox-targets-ipv6/ssh806_ipv6.json
 
+      # SSH on port 22 over IPv4
+      ./mlabconfig.py --format=prom-targets-nodes \
+          --template_target={{hostname}}:22 \
+          --label service=ssh \
+          --label module=ssh_v4_online \
+          --select "${!pattern}" > ${output}/blackbox-targets/ssh.json
+
+      # SSH on port 22 over IPv6
+      ./mlabconfig.py --format=prom-targets-nodes \
+          --template_target={{hostname}}:22 \
+          --label service=ssh \
+          --label module=ssh_v6_online \
+          --label __blackbox_port=${!bbe_port} \
+          --select "${!pattern}" \
+          --decoration "v6" > ${output}/blackbox-targets-ipv6/ssh_ipv6.json
+
       # Sidestream exporter in the npad experiment.
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:9090 \


### PR DESCRIPTION
Since the CoreOS nodes will run SSH on port 22, we need to monitor it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/264)
<!-- Reviewable:end -->
