### PR TITLE
Remove test machines from generated targets when project == mlab-oti.

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -174,11 +174,31 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select "neubot.mlab.(${!pattern})" \
           --decoration "v6" > ${output}/blackbox-targets-ipv6/neubot_ipv6.json
 
-      # snmp_exporter on port 9116.
-      ./mlabconfig.py --format=prom-targets-sites \
+      if [[ ${project} == mlab-oti ]] ; then
+        # snmp_exporter on port 9116.
+        ./mlabconfig.py --format=prom-targets-sites \
+            --select '[a-z]{3}[0-9c]{2}' \
+            --template_target=s1.{{sitename}}.measurement-lab.org \
+            --label service=snmp > \
+                ${output}/snmp-targets/snmpexporter.json
+        # ICMP probe for platform switches
+        ./mlabconfig.py --format=prom-targets-sites \
+          --select '[a-z]{3}[0-9c]{2}' \
           --template_target=s1.{{sitename}}.measurement-lab.org \
-          --label service=snmp > \
-              ${output}/snmp-targets/snmpexporter.json
+          --label module=icmp > \
+              ${output}/blackbox-targets/switches_ping.json
+      else
+        # snmp_exporter on port 9116.
+        ./mlabconfig.py --format=prom-targets-sites \
+            --template_target=s1.{{sitename}}.measurement-lab.org \
+            --label service=snmp > \
+                ${output}/snmp-targets/snmpexporter.json
+        # ICMP probe for platform switches
+        ./mlabconfig.py --format=prom-targets-sites \
+          --template_target=s1.{{sitename}}.measurement-lab.org \
+          --label module=icmp > \
+              ${output}/blackbox-targets/switches_ping.json
+      fi
 
       # inotify_exporter for NDT on port 9393.
       ./mlabconfig.py --format=prom-targets \
@@ -193,12 +213,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --label service=nodeexporter \
           --select "${!pattern}" > \
               ${output}/legacy-targets/nodeexporter.json
-
-      # ICMP probe for platform switches
-      ./mlabconfig.py --format=prom-targets-sites \
-          --template_target=s1.{{sitename}}.measurement-lab.org \
-          --label module=icmp > \
-              ${output}/blackbox-targets/switches_ping.json
 
       # SSH on port 22 over IPv4
       ./mlabconfig.py --format=prom-targets-nodes \


### PR DESCRIPTION
As discussed with @stephen-soltesz, including test sites as monitoring targets for the mlab-oti prometheus configuration was not intentional. This PR adds a --select switch when calling mlabconfig.py to only include sites matching '[a-z]{3}[0-9c]{2}'.

Moreover, since it's not possible to put a test site in GMX mode (the same regex is applied on the GitHub exporter thus test sites are ignored), a side effect of this change is that iad0t/iad1t will not be reported by Rebot as being offline on each run anymore.