### PR TITLE
Generate ndt7_ssl blackbox-exporter targets

### DIFF
--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -82,6 +82,14 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       # production.
       ########################################################################
 
+      # NDT7 SSL on port 443
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}}:443 \
+          --label service=ndt7_ssl \
+          --label module=tcp_v4_online \
+          --select "ndt.iupui.(${!pattern})" > \
+              ${output}/blackbox-targets/ndt7_ssl.json
+
       # NDT "raw" on port 3001 over IPv4
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:3001 \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -82,13 +82,23 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       # production.
       ########################################################################
 
-      # NDT7 SSL on port 443
+      # NDT7 SSL on port 443 over IPv4
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:443 \
           --label service=ndt7 \
           --label module=tcp_v4_online \
           --select "ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt7.json
+
+      # NDT7 SSL on port 443 over IPv6
+      ./mlabconfig.py --format=prom-targets \
+          --template_target={{hostname}}:443 \
+          --label service=ndt7_ipv6 \
+          --label module=tcp_v6_online \
+          --label __blackbox_port=${!bbe_port} \
+          --select "ndt.iupui.(${!pattern})" \
+          --decoration "v6" > \
+              ${output}/blackbox-targets-ipv6/ndt7_ipv6.json
 
       # NDT "raw" on port 3001 over IPv4
       ./mlabconfig.py --format=prom-targets \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -85,10 +85,10 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       # NDT7 SSL on port 443
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:443 \
-          --label service=ndt7_ssl \
+          --label service=ndt7 \
           --label module=tcp_v4_online \
           --select "ndt.iupui.(${!pattern})" > \
-              ${output}/blackbox-targets/ndt7_ssl.json
+              ${output}/blackbox-targets/ndt7.json
 
       # NDT "raw" on port 3001 over IPv4
       ./mlabconfig.py --format=prom-targets \

--- a/generate_prometheus_targets.sh
+++ b/generate_prometheus_targets.sh
@@ -82,7 +82,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       # production.
       ########################################################################
 
-      # NDT7 SSL on port 443 over IPv4
+      # ndt7 SSL on port 443 over IPv4
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:443 \
           --label service=ndt7 \
@@ -90,7 +90,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
           --select "ndt.iupui.(${!pattern})" > \
               ${output}/blackbox-targets/ndt7.json
 
-      # NDT7 SSL on port 443 over IPv6
+      # ndt7 SSL on port 443 over IPv6
       ./mlabconfig.py --format=prom-targets \
           --template_target={{hostname}}:443 \
           --label service=ndt7_ipv6 \


### PR DESCRIPTION
This PR adds blackbox-exporter targets for NDT7 on port 443.

Is it part of https://github.com/m-lab/mlab-ns/issues/188.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/operator/285)
<!-- Reviewable:end -->
